### PR TITLE
feat(prepaint, local-first): integrate DevTools event emission with type-safe API

### DIFF
--- a/packages/local-first/src/broadcast.ts
+++ b/packages/local-first/src/broadcast.ts
@@ -1,3 +1,5 @@
+import { emitModelEvent } from './devtools';
+
 /**
  * Base fields for all broadcast messages
  */
@@ -85,6 +87,13 @@ class ModelBroadcaster {
       if (message.senderId === this.senderId) {
         return;
       }
+
+      emitModelEvent('broadcast', {
+        modelName: message.key,
+        operation: message.type === 'model-patched' ? 'patch' : 'replace',
+        senderId: message.senderId,
+        receivedAt: Date.now(),
+      });
 
       const callbacks = this.listeners.get(message.key);
       if (callbacks) {

--- a/packages/local-first/src/devtools.ts
+++ b/packages/local-first/src/devtools.ts
@@ -1,0 +1,118 @@
+declare const __FIRSTTX_DEV__: boolean;
+
+interface DevToolsAPI {
+  emit: (event: unknown) => void;
+}
+
+interface ModelInitData {
+  modelName: string;
+  ttl: number;
+  hasInitialData: boolean;
+  version?: number;
+}
+
+interface ModelLoadData {
+  modelName: string;
+  dataSize: number;
+  age: number;
+  isStale: boolean;
+  duration: number;
+}
+
+interface ModelPatchData {
+  modelName: string;
+  operation: string;
+  duration: number;
+}
+
+interface ModelReplaceData {
+  modelName: string;
+  dataSize: number;
+  source: 'sync' | 'broadcast' | 'manual';
+  duration: number;
+}
+
+interface ModelSyncStartData {
+  modelName: string;
+  trigger: 'mount' | 'manual' | 'stale';
+  currentAge: number;
+}
+
+interface ModelSyncSuccessData {
+  modelName: string;
+  dataSize: number;
+  duration: number;
+  hadChanges: boolean;
+}
+
+interface ModelSyncErrorData {
+  modelName: string;
+  error: string;
+  duration: number;
+  willRetry: boolean;
+}
+
+interface ModelBroadcastData {
+  modelName: string;
+  operation: 'patch' | 'replace';
+  senderId: string;
+  receivedAt: number;
+}
+
+interface ModelValidationErrorData {
+  modelName: string;
+  error: string;
+  path?: string;
+}
+
+const EVENT_PRIORITY: Record<string, number> = {
+  init: 0,
+  load: 0,
+  patch: 0,
+  broadcast: 0,
+  replace: 1,
+  'sync.start': 1,
+  'sync.success': 1,
+  'sync.error': 2,
+  'validation.error': 2,
+};
+
+export function emitModelEvent(type: 'init', data: ModelInitData): void;
+export function emitModelEvent(type: 'load', data: ModelLoadData): void;
+export function emitModelEvent(type: 'patch', data: ModelPatchData): void;
+export function emitModelEvent(type: 'replace', data: ModelReplaceData): void;
+export function emitModelEvent(type: 'sync.start', data: ModelSyncStartData): void;
+export function emitModelEvent(type: 'sync.success', data: ModelSyncSuccessData): void;
+export function emitModelEvent(type: 'sync.error', data: ModelSyncErrorData): void;
+export function emitModelEvent(type: 'broadcast', data: ModelBroadcastData): void;
+export function emitModelEvent(type: 'validation.error', data: ModelValidationErrorData): void;
+
+export function emitModelEvent(type: string, data: unknown): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const api = window.__FIRSTTX_DEVTOOLS__;
+    if (!api || typeof api.emit !== 'function') return;
+
+    const event = {
+      id: crypto.randomUUID(),
+      category: 'model' as const,
+      type,
+      timestamp: Date.now(),
+      data,
+      priority: EVENT_PRIORITY[type] ?? 1,
+    };
+
+    api.emit(event);
+  } catch (error) {
+    if (typeof __FIRSTTX_DEV__ !== 'undefined' && __FIRSTTX_DEV__) {
+      console.warn('[FirstTx Model] DevTools emit failed:', error);
+    }
+  }
+}
+
+declare global {
+  interface Window {
+    __FIRSTTX_DEVTOOLS__?: DevToolsAPI;
+  }
+}


### PR DESCRIPTION
## What

Add comprehensive DevTools integration across Prepaint and Local-First packages:

Prepaint
- Add type-safe emitDevToolsEvent with function overloads
- Implement event priority system (LOW/NORMAL/HIGH)
- Emit capture events with performance metrics (bodySize, duration)
- Emit restore events with snapshot age and restore duration
- Emit handoff events with hydration strategy
- Emit hydration.error events with mismatch type detection
- Emit storage.error events for IndexedDB failures

Local-First
- Add type-safe emitModelEvent with function overloads
- Implement event priority mapping for all event types
- Emit init events on model definition
- Emit load events with data size and staleness info
- Emit patch/replace events with operation duration
- Emit sync.start/success/error with trigger detection
- Emit broadcast events for cross-tab synchronization
- Emit validation.error events with schema path

Technical improvements
- Performance measurement using performance.now()
- Trigger tracking (mount/manual/stale) for sync events
- Graceful degradation when DevTools API unavailable
- Development-only error logging for emit failures

## Why

<!-- Why? -->

## Testing

<!-- Tested? -->

---

**Breaking?** <!-- Yes/No + migration if needed -->
