### PR TITLE
refactor(local-first, tx, prepaint): prevent crashes when using FirstTx in SSR framework client components

### DIFF
--- a/packages/local-first/src/hooks.ts
+++ b/packages/local-first/src/hooks.ts
@@ -2,6 +2,7 @@ import { useSyncExternalStore, useState, useEffect, useCallback, useRef } from '
 import type { SyncOptions, SyncedModelResult, Fetcher } from './types';
 import type { Model } from './model';
 import { emitModelEvent } from './devtools';
+import { supportsViewTransition } from './utils';
 
 /**
  * React hook for subscribing to model changes
@@ -71,7 +72,7 @@ export function useSyncedModel<T>(
       const currentData = model.getCachedSnapshot();
       const data = await fetcherRef.current(currentData);
 
-      if ('startViewTransition' in document) {
+      if (supportsViewTransition()) {
         await document.startViewTransition(() => model.replace(data)).finished;
       } else {
         await model.replace(data);

--- a/packages/local-first/src/utils.ts
+++ b/packages/local-first/src/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Checks if ViewTransition API is available
+ * @returns true if document exists and supports ViewTransition
+ */
+export function supportsViewTransition(): boolean {
+  return (
+    typeof document !== 'undefined' &&
+    'startViewTransition' in document &&
+    typeof document.startViewTransition === 'function'
+  );
+}

--- a/packages/prepaint/src/helpers.ts
+++ b/packages/prepaint/src/helpers.ts
@@ -6,6 +6,7 @@ import type { Snapshot } from './types';
 import { removeOverlay } from './overlay';
 import { HydrationError } from './errors';
 import { emitDevToolsEvent } from './devtools';
+import { supportsViewTransition } from './utils';
 
 export interface CreateFirstTxRootOptions {
   transition?: boolean;
@@ -127,11 +128,7 @@ export function createFirstTxRoot(
 
           if (bailed) return;
           bailed = true;
-          if (
-            'startViewTransition' in document &&
-            typeof document.startViewTransition === 'function' &&
-            transition
-          ) {
+          if (supportsViewTransition() && transition) {
             document.startViewTransition(() => {
               runClientReset();
             });
@@ -154,11 +151,7 @@ export function createFirstTxRoot(
         );
       });
     };
-    if (
-      'startViewTransition' in document &&
-      typeof document.startViewTransition === 'function' &&
-      transition
-    ) {
+    if (supportsViewTransition() && transition) {
       document.startViewTransition(runHydrate);
     } else {
       runHydrate();

--- a/packages/prepaint/src/utils.ts
+++ b/packages/prepaint/src/utils.ts
@@ -23,3 +23,15 @@ export function openDB(): Promise<IDBDatabase> {
     };
   });
 }
+
+/**
+ * Checks if ViewTransition API is available
+ * @returns true if document exists and supports ViewTransition
+ */
+export function supportsViewTransition(): boolean {
+  return (
+    typeof document !== 'undefined' &&
+    'startViewTransition' in document &&
+    typeof document.startViewTransition === 'function'
+  );
+}

--- a/packages/tx/src/transaction.ts
+++ b/packages/tx/src/transaction.ts
@@ -2,6 +2,7 @@ import type { TxOptions, TxStatus, TxStep, StepOptions } from './types';
 import { CompensationFailedError, TransactionTimeoutError, TransactionStateError } from './errors';
 import { executeWithRetry } from './retry';
 import { emitTxEvent } from './devtools';
+import { supportsViewTransition } from './utils';
 
 export class Transaction {
   private steps: TxStep<unknown>[] = [];
@@ -198,7 +199,7 @@ export class Transaction {
     };
 
     try {
-      if (this.options.transition && 'startViewTransition' in document) {
+      if (this.options.transition && supportsViewTransition()) {
         await document.startViewTransition(rollbackFn).finished;
       } else {
         await rollbackFn();

--- a/packages/tx/src/utils.ts
+++ b/packages/tx/src/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Checks if ViewTransition API is available
+ * @returns true if document exists and supports ViewTransition
+ */
+export function supportsViewTransition(): boolean {
+  return (
+    typeof document !== 'undefined' &&
+    'startViewTransition' in document &&
+    typeof document.startViewTransition === 'function'
+  );
+}


### PR DESCRIPTION
## What

```ts
function supportsViewTransition(): boolean {
  return (
    typeof document !== 'undefined' &&
    'startViewTransition' in document &&
    typeof document.startViewTransition === 'function'
  );
}

// Usage
if (supportsViewTransition()) {
  await document.startViewTransition(fn).finished;
} else {
  await fn(); // Graceful fallback
}
```

## Why

<!-- Why? -->

## Testing

<!-- Tested? -->

---

**Breaking?** <!-- Yes/No + migration if needed -->
