### PR TITLE
refactor(local-first, devtools): provide BroadcastChannel fallback for unsupported environments

### DIFF
--- a/packages/devtools/src/bridge/helpers.ts
+++ b/packages/devtools/src/bridge/helpers.ts
@@ -27,6 +27,8 @@ import type {
   TxTimeoutEvent,
   SystemReadyEvent,
   SystemErrorEvent,
+  ModelBroadcastFallbackEvent,
+  ModelBroadcastSkippedEvent,
 } from './types';
 
 function generateId(): string {
@@ -182,6 +184,32 @@ export function createModelBroadcastEvent(data: ModelBroadcastEvent['data']): Mo
     id: generateId(),
     category: 'model',
     type: 'broadcast',
+    timestamp: Date.now(),
+    priority: EventPriority.LOW,
+    data,
+  };
+}
+
+export function createModelBroadcastFallbackEvent(
+  data: ModelBroadcastFallbackEvent['data'],
+): ModelBroadcastFallbackEvent {
+  return {
+    id: generateId(),
+    category: 'model',
+    type: 'broadcast.fallback',
+    timestamp: Date.now(),
+    priority: EventPriority.NORMAL,
+    data,
+  };
+}
+
+export function createModelBroadcastSkippedEvent(
+  data: ModelBroadcastSkippedEvent['data'],
+): ModelBroadcastSkippedEvent {
+  return {
+    id: generateId(),
+    category: 'model',
+    type: 'broadcast.skipped',
     timestamp: Date.now(),
     priority: EventPriority.LOW,
     data,

--- a/packages/devtools/src/bridge/types.ts
+++ b/packages/devtools/src/bridge/types.ts
@@ -177,6 +177,27 @@ export interface ModelValidationErrorEvent extends BaseEvent {
   };
 }
 
+export interface ModelBroadcastFallbackEvent extends BaseEvent {
+  category: 'model';
+  type: 'broadcast.fallback';
+  priority: EventPriority.NORMAL;
+  data: {
+    reason: string;
+    environment: 'browser' | 'ssr' | 'unknown';
+  };
+}
+
+export interface ModelBroadcastSkippedEvent extends BaseEvent {
+  category: 'model';
+  type: 'broadcast.skipped';
+  priority: EventPriority.LOW;
+  data: {
+    modelName: string;
+    operation: 'model-patched' | 'model-replaced' | 'model-deleted';
+    reason: string;
+  };
+}
+
 export type ModelEvent =
   | ModelInitEvent
   | ModelLoadEvent
@@ -186,6 +207,8 @@ export type ModelEvent =
   | ModelSyncSuccessEvent
   | ModelSyncErrorEvent
   | ModelBroadcastEvent
+  | ModelBroadcastFallbackEvent
+  | ModelBroadcastSkippedEvent
   | ModelValidationErrorEvent;
 
 export interface TxStartEvent extends BaseEvent {

--- a/packages/local-first/src/broadcast.ts
+++ b/packages/local-first/src/broadcast.ts
@@ -1,5 +1,7 @@
 import { emitModelEvent } from './devtools';
 
+declare const __FIRSTTX_DEV__: boolean;
+
 /**
  * Base fields for all broadcast messages
  */
@@ -29,16 +31,58 @@ function generateSenderId(): string {
 }
 
 /**
+ * Fallback implementation when BroadcastChannel is unavailable (SSR, old browsers)
+ * Provides no-op methods to allow graceful degradation without crashes
+ */
+class FallbackChannel {
+  postMessage(): void {
+    // No-op: Cross-tab synchronization unavailable
+  }
+  dispatchEvent(): boolean {
+    return false; // no-op
+  }
+
+  set onmessage(_handler: ((event: MessageEvent) => void) | null) {
+    // No-op: Cannot receive messages without BroadcastChannel
+  }
+
+  close(): void {
+    // No-op: No resources to clean up
+  }
+}
+
+/**
  * Manages cross-tab model synchronization via BroadcastChannel
  */
 class ModelBroadcaster {
   private static instance?: ModelBroadcaster;
-  private channel: BroadcastChannel;
+  private channel: BroadcastChannel | FallbackChannel;
   private senderId: string;
   private listeners = new Map<string, Set<() => void>>();
+  private usingFallback: boolean;
 
   private constructor() {
-    this.channel = new BroadcastChannel('firsttx:models');
+    if (typeof BroadcastChannel !== 'undefined') {
+      this.channel = new BroadcastChannel('firsttx:models');
+      this.usingFallback = false;
+    } else {
+      this.channel = new FallbackChannel();
+      this.usingFallback = true;
+
+      if (typeof __FIRSTTX_DEV__ !== 'undefined' && __FIRSTTX_DEV__) {
+        console.warn(
+          '[FirstTx] BroadcastChannel is not available. ' +
+            'Cross-tab synchronization will not work. ' +
+            'Data will sync on page refresh via IndexedDB.',
+        );
+      }
+
+      emitModelEvent('broadcast.fallback', {
+        reason: 'BroadcastChannel not supported',
+        environment: typeof window !== 'undefined' ? 'browser' : 'ssr',
+      });
+    }
+
     this.senderId = generateSenderId();
     this.setupListener();
   }
@@ -78,6 +122,14 @@ class ModelBroadcaster {
     };
 
     this.channel.postMessage(fullMessage);
+
+    if (this.usingFallback) {
+      emitModelEvent('broadcast.skipped', {
+        modelName: message.key,
+        operation: message.type,
+        reason: 'Fallback mode active',
+      });
+    }
   }
 
   private setupListener(): void {

--- a/packages/local-first/src/devtools.ts
+++ b/packages/local-first/src/devtools.ts
@@ -65,11 +65,24 @@ interface ModelValidationErrorData {
   path?: string;
 }
 
+interface ModelBroadcastFallbackData {
+  reason: string;
+  environment: 'browser' | 'ssr' | 'unknown';
+}
+
+interface ModelBroadcastSkippedData {
+  modelName: string;
+  operation: 'model-patched' | 'model-replaced' | 'model-deleted';
+  reason: string;
+}
+
 const EVENT_PRIORITY: Record<string, number> = {
   init: 0,
   load: 0,
   patch: 0,
   broadcast: 0,
+  'broadcast.fallback': 1,
+  'broadcast.skipped': 0,
   replace: 1,
   'sync.start': 1,
   'sync.success': 1,
@@ -85,6 +98,8 @@ export function emitModelEvent(type: 'sync.start', data: ModelSyncStartData): vo
 export function emitModelEvent(type: 'sync.success', data: ModelSyncSuccessData): void;
 export function emitModelEvent(type: 'sync.error', data: ModelSyncErrorData): void;
 export function emitModelEvent(type: 'broadcast', data: ModelBroadcastData): void;
+export function emitModelEvent(type: 'broadcast.fallback', data: ModelBroadcastFallbackData): void;
+export function emitModelEvent(type: 'broadcast.skipped', data: ModelBroadcastSkippedData): void;
 export function emitModelEvent(type: 'validation.error', data: ModelValidationErrorData): void;
 
 export function emitModelEvent(type: string, data: unknown): void {


### PR DESCRIPTION
## What

Add FallbackChannel no-op implementation to prevent crashes in SSR and old browsers.
Maintains API compatibility while gracefully degrading cross-tab sync functionality.

- Detect BroadcastChannel support with typeof check
- Emit broadcast.fallback and broadcast.skipped events
- Add comprehensive fallback mode tests

## Why

<!-- Why? -->

## Testing

<!-- Tested? -->

---

**Breaking?** <!-- Yes/No + migration if needed -->
