### PR TITLE
fix(prepaint): protect reset() call with try-finally in installRootGuard

### DIFF
--- a/packages/prepaint/src/helpers.ts
+++ b/packages/prepaint/src/helpers.ts
@@ -40,8 +40,11 @@ function installRootGuard(container: Element, getRoot: () => Root | null, reset:
         getRoot()?.unmount?.();
       } catch {}
       container.innerHTML = '';
-      reset();
-      resetting = false;
+      try {
+        reset();
+      } finally {
+        resetting = false;
+      }
     }
   };
   const mo = new MutationObserver(() => check());


### PR DESCRIPTION
## What

- Wrap reset() call in try-finally in installRootGuard
- Prevents permanent lockup if reset() throws exception

## Why

<!-- Why? -->

## Testing

<!-- Tested? -->

---

**Breaking?** <!-- Yes/No + migration if needed -->
