### PR TITLE
feat(prepaint): add opt-in snapshot policy and storage hardening

### DIFF
--- a/.changeset/calm-routes-prepaint.md
+++ b/.changeset/calm-routes-prepaint.md
@@ -1,0 +1,5 @@
+---
+'@firsttx/prepaint': minor
+---
+
+Require an explicit route policy for snapshot capture and restore, add configurable TTL, payload-size, and CSS limits, migrate storage to schema v2, and emit an external self-starting Vite boot asset by default.

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ docs/temp.*
 !.vscode/settings.json
 .vercel
 .env*.local
+.claude/**/*.json
+artifacts/

--- a/README.md
+++ b/README.md
@@ -72,11 +72,15 @@ pnpm add @firsttx/prepaint @firsttx/local-first @firsttx/tx
 import { firstTx } from '@firsttx/prepaint/plugin/vite';
 
 export default defineConfig({
-  plugins: [firstTx()],
+  plugins: [
+    firstTx({
+      policy: { routes: ['/dashboard', '/cart'] },
+    }),
+  ],
 });
 ```
 
-> Snapshot restore always uses a non-interactive overlay outside the React root. The legacy `overlay` and `overlayRoutes` options are deprecated no-ops.
+> Prepaint is off until `policy.routes` explicitly opts paths in. Snapshot restore always uses a non-interactive overlay outside the React root.
 
 ### 2. Entry Point
 

--- a/apps/docs/components/landing/quick-start.tsx
+++ b/apps/docs/components/landing/quick-start.tsx
@@ -72,7 +72,9 @@ import { defineConfig } from "vite";
 import { firstTx } from "@firsttx/prepaint/plugin/vite";
 
 export default defineConfig({
-  plugins: [firstTx()],
+  plugins: [
+    firstTx({ policy: { routes: ["/dashboard", "/cart"] } }),
+  ],
 });
               `}
             />

--- a/apps/docs/content/ai/en/getting-started.md
+++ b/apps/docs/content/ai/en/getting-started.md
@@ -71,10 +71,12 @@ import { firstTx } from "@firsttx/prepaint/plugin/vite";
 export default defineConfig({
   plugins: [
     react(),
-    firstTx(),
+    firstTx({ policy: { routes: ['/dashboard', '/cart'] } }),
   ],
 });
 ```
+
+Prepaint is disabled until `policy.routes` explicitly opts exact pathnames in.
 
 #### 2. Entry point configuration
 

--- a/apps/docs/content/ai/en/prepaint.md
+++ b/apps/docs/content/ai/en/prepaint.md
@@ -8,7 +8,7 @@ Prepaint reduces the visible blank interval on revisit in CSR React applications
 
 ### Capture phase
 
-When the user leaves the page (on `visibilitychange`, `pagehide`, or `beforeunload` events), the following steps are executed:
+During idle time and once more on `visibilitychange` or `pagehide`, the following steps are executed:
 
 1. Clone the first child DOM node of the `#root` element.
 2. Clear the contents of elements with the `data-firsttx-volatile` attribute.
@@ -74,15 +74,25 @@ import react from '@vitejs/plugin-react';
 import { firstTx } from '@firsttx/prepaint/plugin/vite';
 
 export default defineConfig({
-  plugins: [react(), firstTx()],
+  plugins: [
+    react(),
+    firstTx({
+      policy: { routes: ['/dashboard', '/cart'] },
+    }),
+  ],
 });
 ```
+
+The policy is an exact pathname allowlist shared by capture, restore, and pruning. Missing or empty routes disable Prepaint. Defaults are a 7-day TTL, 1 MiB UTF-8 payload limit, and CSS capture enabled. The boot script is an external `/firsttx-boot.js` asset by default; use `inline: true` only with an intentional CSP hash.
+
+Restored HTML is sanitized, but captured CSS is visual cache data and is not a general CSS sanitization boundary. Set `includeStyles: false` for routes with user-controlled or sensitive CSS.
 
 ### Plugin options
 
 | Option            | Type                                                   | Default              | Description                                                                                          |
 | ----------------- | ------------------------------------------------------ | -------------------- | ---------------------------------------------------------------------------------------------------- |
-| `inline`          | `boolean`                                              | `true`               | Inlines the boot script into HTML                                                                    |
+| `inline`          | `boolean`                                              | `false`              | Inlines the boot script into HTML; intended for CSP hash deployments                                 |
+| `policy`          | `PrepaintPolicy`                                       | disabled             | Exact routes plus optional TTL, byte limit, and CSS capture settings                                 |
 | `minify`          | `boolean`                                              | `true` in production | Whether to minify the boot script. In development, the default is `false`.                           |
 | `injectTo`        | `'head' \| 'head-prepend' \| 'body' \| 'body-prepend'` | `'head-prepend'`     | Where to inject the script                                                                           |
 | `nonce`           | `string \| (() => string)`                             | -                    | CSP nonce embedded when Vite generates the output; static output cannot create one per HTTP response |

--- a/apps/docs/content/ai/ko/getting-started.md
+++ b/apps/docs/content/ai/ko/getting-started.md
@@ -71,10 +71,12 @@ import { firstTx } from "@firsttx/prepaint/plugin/vite";
 export default defineConfig({
   plugins: [
     react(),
-    firstTx(),
+    firstTx({ policy: { routes: ['/dashboard', '/cart'] } }),
   ],
 });
 ```
+
+`policy.routes`에 정확한 pathname을 명시하기 전에는 Prepaint가 비활성화됩니다.
 
 #### 2. 엔트리 포인트 설정
 

--- a/apps/docs/content/ai/ko/prepaint.md
+++ b/apps/docs/content/ai/ko/prepaint.md
@@ -8,7 +8,7 @@ Prepaint는 CSR React 앱 재방문의 빈 화면 시간을 줄입니다. DOM sn
 
 ### 캡처 단계
 
-사용자가 페이지를 떠날 때(visibilitychange, pagehide, beforeunload 이벤트) 다음 작업이 수행됩니다:
+유휴 시점과 `visibilitychange` 또는 `pagehide` 마지막 시점에 다음 작업이 수행됩니다:
 
 1. `#root` 요소의 첫 번째 자식 DOM을 복제합니다
 2. `data-firsttx-volatile` 속성이 있는 요소의 내용을 비웁니다
@@ -74,15 +74,25 @@ import react from '@vitejs/plugin-react';
 import { firstTx } from '@firsttx/prepaint/plugin/vite';
 
 export default defineConfig({
-  plugins: [react(), firstTx()],
+  plugins: [
+    react(),
+    firstTx({
+      policy: { routes: ['/dashboard', '/cart'] },
+    }),
+  ],
 });
 ```
+
+정책은 캡처·복원·정리가 공유하는 정확한 pathname allowlist입니다. 누락하거나 비우면 Prepaint가 비활성화됩니다. 기본값은 TTL 7일, UTF-8 payload 최대 1 MiB, CSS 포함입니다. 부트 스크립트는 기본적으로 외부 `/firsttx-boot.js` 자산이며, `inline: true`는 CSP hash를 의도적으로 관리할 때 사용합니다.
+
+복원 HTML은 sanitize하지만 저장 CSS는 시각 캐시일 뿐 범용 CSS sanitization 경계가 아닙니다. 사용자 제어 또는 민감 CSS가 있는 route에서는 `includeStyles: false`를 사용하세요.
 
 ### 플러그인 옵션
 
 | 옵션              | 타입                                                   | 기본값              | 설명                                                                                                      |
 | ----------------- | ------------------------------------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------- |
-| `inline`          | `boolean`                                              | `true`              | 부트 스크립트를 HTML에 인라인으로 삽입합니다                                                              |
+| `inline`          | `boolean`                                              | `false`             | CSP hash 배포를 위해 부트 스크립트를 HTML에 인라인으로 삽입합니다                                         |
+| `policy`          | `PrepaintPolicy`                                       | 비활성화            | 정확한 route와 선택 TTL, byte 제한, CSS 저장 설정입니다                                                   |
 | `minify`          | `boolean`                                              | 프로덕션에서 `true` | 부트 스크립트 minify 여부입니다. 개발 환경에서는 기본 `false`입니다                                       |
 | `injectTo`        | `'head' \| 'head-prepend' \| 'body' \| 'body-prepend'` | `'head-prepend'`    | 스크립트 삽입 위치입니다                                                                                  |
 | `nonce`           | `string \| (() => string)`                             | -                   | Vite가 결과물을 생성할 때 포함하는 CSP nonce입니다. 정적 출력은 HTTP 응답마다 새 nonce를 만들 수 없습니다 |

--- a/apps/docs/content/docs/getting-started.en.mdx
+++ b/apps/docs/content/docs/getting-started.en.mdx
@@ -62,7 +62,7 @@ import { firstTx } from "@firsttx/prepaint/plugin/vite";
 export default defineConfig({
   plugins: [
     react(),
-    firstTx(),
+    firstTx({ policy: { routes: ["/dashboard", "/cart"] } }),
   ],
 });
 ```
@@ -72,6 +72,8 @@ At build time, this plugin injects a small boot script into your HTML. The scrip
 1. Reads the last DOM snapshot from IndexedDB on page load.
 2. If a valid snapshot is found, restores it before React.
 3. Then lets React mount the real app.
+
+Prepaint is disabled until `policy.routes` explicitly opts exact pathnames in.
 
 <Callout type="info" title="Visual overlay is the default">
   Snapshots always render in a non-interactive overlay outside the React root. React mounts into an empty root, and the overlay is removed after the first commit.

--- a/apps/docs/content/docs/getting-started.ko.mdx
+++ b/apps/docs/content/docs/getting-started.ko.mdx
@@ -61,7 +61,7 @@ import { firstTx } from "@firsttx/prepaint/plugin/vite";
 export default defineConfig({
   plugins: [
     react(),
-    firstTx(),
+    firstTx({ policy: { routes: ["/dashboard", "/cart"] } }),
   ],
 });
 ```
@@ -71,6 +71,8 @@ export default defineConfig({
 1. 페이지 진입 시 IndexedDB에서 마지막 DOM 스냅샷을 읽어오고
 2. 유효한 스냅샷이 있다면 React보다 먼저 복원한 뒤
 3. 그 다음에 실제 React 앱이 마운트되도록 연결합니다.
+
+`policy.routes`에 정확한 pathname을 명시하기 전에는 Prepaint가 비활성화됩니다.
 
 <Callout type="info" title="Visual overlay가 기본입니다">
   스냅샷은 항상 React root 밖의 비상호작용 overlay에 표시됩니다. React는 빈 root에 마운트되고 첫 commit 뒤 overlay가 제거됩니다.

--- a/apps/docs/content/docs/prepaint.en.mdx
+++ b/apps/docs/content/docs/prepaint.en.mdx
@@ -56,17 +56,17 @@ import { firstTx } from "@firsttx/prepaint/plugin/vite";
 export default defineConfig({
   plugins: [
     react(),
-    firstTx(),
+    firstTx({ policy: { routes: ["/dashboard", "/cart"] } }),
   ],
 });
 ```
 
-- `firstTx()` bundles the boot script (using esbuild internally) and injects it as an IIFE into your HTML.
+- `firstTx()` bundles a self-starting boot script and emits `/firsttx-boot.js` by default.
 - Default behavior,
-  - `inline: true` - bundle is inlined into the HTML (no extra network request)
+  - `inline: false` - external classic script for static CSP deployments
   - `minify` is enabled only in production
 
-- If you prefer a separate file, you can set `inline: false` and load it via `<script src="/firsttx-boot.js">`.
+- Set `inline: true` only when you intentionally manage a CSP hash for the generated inline script.
 
 <Callout type="info" title="Visual overlay">
   Snapshot restore always uses a non-interactive Shadow DOM overlay outside the React root.
@@ -78,10 +78,14 @@ export default defineConfig({
       <code>nonce: string</code> - nonce embedded in generated output; static Vite output cannot create a per-response nonce
     </li>
   </ul>
-  <code>setupCapture</code> with its <code>routes</code> option can restrict new captures; restore-side route filtering is not available in this release.
+  <code>policy.routes</code> is an exact pathname allowlist shared by capture, restore, and record pruning. Missing or empty routes disable Prepaint.
 </Callout>
 
-For static hosting, prefer an external boot asset or a CSP hash. A nonce passed to the Vite plugin is generated at build time, not once per HTTP response.
+Policy defaults are a 7-day TTL, 1 MiB UTF-8 payload limit, and CSS capture enabled. Schema v2 clears legacy v1 records once. For static hosting, use the default external asset or opt into an inline CSP hash. A nonce passed to the Vite plugin is generated at build time, not once per HTTP response.
+
+<Callout type="warning" title="CSS threat boundary">
+  Restored HTML is sanitized, but captured CSS is visual cache data and is not a general CSS sanitization boundary. Set <code>includeStyles: false</code> for routes with user-controlled or sensitive CSS.
+</Callout>
 
 ---
 
@@ -223,7 +227,7 @@ async function boot() {
 
 ## 3. Capture pipeline: what DOM is stored?
 
-Right before the user leaves the page, Prepaint stores a snapshot of the **first child of `#root`**.
+During idle time and once more when the page is hidden, Prepaint stores a snapshot of the **first child of `#root`**.
 
 ### 3-1. Capture triggers
 
@@ -231,10 +235,8 @@ Right before the user leaves the page, Prepaint stores a snapshot of the **first
 
 - `visibilitychange` (when `document.visibilityState === "hidden"`)
 - `pagehide`
-- `beforeunload`
 
-When these events occur, it queues the capture using `queueMicrotask`.
-To avoid capturing too frequently, it ignores redundant calls in a short time window in the same tab.
+It also schedules an idle capture while the page is active. Concurrent writes are deduplicated, and no `beforeunload` listener is registered.
 
 ### 3-2. DOM serialization & scrubbing
 

--- a/apps/docs/content/docs/prepaint.ko.mdx
+++ b/apps/docs/content/docs/prepaint.ko.mdx
@@ -58,23 +58,27 @@ import { firstTx } from "@firsttx/prepaint/plugin/vite";
 export default defineConfig({
   plugins: [
     react(),
-    firstTx(),
+    firstTx({ policy: { routes: ["/dashboard", "/cart"] } }),
   ],
 });
 ```
 
-- `firstTx()`는 HTML에 작은 IIFE 부트 스니펫(~1.7KB)을 인라인으로 주입하거나(기본값), 별도의 `/firsttx-boot.js`로 서빙할 수 있습니다.
+- `firstTx()`는 기본적으로 self-starting `/firsttx-boot.js` 외부 자산을 생성합니다.
 - 이 스니펫이 **React가 로드되기 전에** IndexedDB에서 스냅샷을 읽어와 DOM을 복원합니다.
 
 주요 플러그인 옵션(요약),
 
-- `inline` (`boolean`, 기본 `true`): 부트 스크립트를 HTML에 인라인 삽입할지 여부
+- `inline` (`boolean`, 기본 `false`): CSP hash를 직접 관리할 때 부트 스크립트를 HTML에 인라인 삽입할지 여부
 - `injectTo` (`"head" | "head-prepend" | "body" | "body-prepend"`, 기본 `"head"`): 스크립트 삽입 위치
 - `nonce` (`string`): 생성 결과물에 포함할 nonce. 정적 Vite 출력에서는 응답별 nonce를 만들 수 없음
 
-정적 호스팅에서는 external boot asset이나 CSP hash를 우선하세요. Vite 플러그인에 전달한 nonce는 HTTP 응답마다가 아니라 빌드 시점에 생성됩니다.
+`policy.routes`는 캡처·복원·record 정리가 공유하는 정확한 pathname allowlist입니다. 누락하거나 비우면 Prepaint가 비활성화됩니다. 기본 정책은 TTL 7일, UTF-8 payload 최대 1 MiB, CSS 포함입니다. DB schema v2 진입 시 기존 v1 record를 한 번 폐기합니다.
 
-기존 `overlay`, `overlayRoutes` 옵션은 한 릴리스 동안 deprecated no-op으로 허용됩니다. 복원 방식은 항상 오버레이입니다. `setupCapture({ routes })`로 새 캡처를 제한할 수 있지만, restore-side route filtering은 이 릴리스에서 제공하지 않습니다.
+정적 호스팅에서는 기본 external boot asset을 사용하거나 `inline: true`와 CSP hash를 함께 사용하세요. Vite 플러그인에 전달한 nonce는 HTTP 응답마다가 아니라 빌드 시점에 생성됩니다. 기존 `overlay`, `overlayRoutes` 옵션은 한 릴리스 동안 deprecated no-op입니다.
+
+<Callout type="warning" title="CSS threat boundary">
+  복원 HTML은 sanitize하지만 저장 CSS는 시각 캐시일 뿐 범용 CSS sanitization 경계가 아닙니다. 사용자 제어 또는 민감 CSS가 있는 route에서는 <code>includeStyles: false</code>를 사용하세요.
+</Callout>
 
 ---
 
@@ -193,7 +197,7 @@ Prepaint의 핵심은 **HTML에 주입된 부트 스크립트**입니다.
 
 ## 3. 캡처 파이프라인: 어떤 DOM이 저장되나요?
 
-사용자가 페이지를 떠나기 직전에 Prepaint는 **`#root`의 첫 번째 자식**을 직렬화해서 IndexedDB에 저장합니다.
+활성 페이지의 유휴 시점과 페이지가 숨겨지는 마지막 시점에 Prepaint는 **`#root`의 첫 번째 자식**을 직렬화해서 IndexedDB에 저장합니다.
 
 ### 3‑1. 캡처 트리거
 
@@ -201,9 +205,8 @@ Prepaint의 핵심은 **HTML에 주입된 부트 스크립트**입니다.
 
 - `visibilitychange` (숨김 상태로 전환될 때)
 - `pagehide`
-- `beforeunload`
 
-이 이벤트가 발생하면 `queueMicrotask`로 캡처 작업을 한 번만 예약하여, 연속 이벤트에도 중복 캡처를 막습니다.
+페이지가 활성 상태일 때 idle capture도 예약합니다. 진행 중인 write는 중복 실행하지 않으며 `beforeunload` listener는 등록하지 않습니다.
 
 ### 3‑2. 직렬화 & 민감 데이터 처리
 

--- a/apps/playground/src/data/learning-paths.ts
+++ b/apps/playground/src/data/learning-paths.ts
@@ -75,7 +75,10 @@ createFirstTxRoot(document.getElementById('root')!, <App />);`,
     codeSnippet: `import { firstTx } from '@firsttx/prepaint/plugin/vite';
 
 export default defineConfig({
-  plugins: [react(), firstTx()],
+  plugins: [
+    react(),
+    firstTx({ policy: { routes: ['/prepaint/route-switching'] } }),
+  ],
 });`,
     codeTitle: 'Vite Plugin Setup',
     docsLink: 'https://firsttx-docs.vercel.app/docs/prepaint',

--- a/apps/playground/tests/prepaint-handoff.spec.ts
+++ b/apps/playground/tests/prepaint-handoff.spec.ts
@@ -1,5 +1,31 @@
 import { expect, test } from '@playwright/test';
 
+async function waitForSnapshot(page: import('@playwright/test').Page, route: string) {
+  await page.waitForFunction(
+    async ({ routeKey }) => {
+      return new Promise<boolean>((resolve) => {
+        const request = indexedDB.open('firsttx-prepaint', 2);
+        request.onerror = () => resolve(false);
+        request.onsuccess = () => {
+          const db = request.result;
+          const tx = db.transaction('snapshots', 'readonly');
+          const getRequest = tx.objectStore('snapshots').get(routeKey);
+          getRequest.onerror = () => {
+            db.close();
+            resolve(false);
+          };
+          getRequest.onsuccess = () => {
+            const found = Boolean(getRequest.result);
+            db.close();
+            resolve(found);
+          };
+        };
+      });
+    },
+    { routeKey: route },
+  );
+}
+
 test.describe('Prepaint visual handoff', () => {
   test('keeps the visual overlay until delayed React commits', async ({ page }) => {
     const root = page.locator('#root');
@@ -13,26 +39,7 @@ test.describe('Prepaint visual handoff', () => {
       window.dispatchEvent(new PageTransitionEvent('pagehide'));
     });
 
-    await page.waitForFunction(async () => {
-      return new Promise<boolean>((resolve) => {
-        const request = indexedDB.open('firsttx-prepaint', 1);
-        request.onerror = () => resolve(false);
-        request.onsuccess = () => {
-          const db = request.result;
-          const tx = db.transaction('snapshots', 'readonly');
-          const getRequest = tx.objectStore('snapshots').get('/prepaint/heavy');
-          getRequest.onerror = () => {
-            db.close();
-            resolve(false);
-          };
-          getRequest.onsuccess = () => {
-            const found = Boolean(getRequest.result);
-            db.close();
-            resolve(found);
-          };
-        };
-      });
-    });
+    await waitForSnapshot(page, '/prepaint/heavy');
 
     let releaseMain!: () => void;
     const mainGate = new Promise<void>((resolve) => {
@@ -62,5 +69,97 @@ test.describe('Prepaint visual handoff', () => {
     await expect(grid).toBeVisible();
     await expect(overlay).toHaveCount(0);
     await expect(page.locator('html')).not.toHaveAttribute('data-prepaint');
+  });
+
+  test('stores route-switching snapshots under exact route keys', async ({ page }) => {
+    await page.goto('/prepaint/route-switching/dashboard', { waitUntil: 'networkidle' });
+    await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent('pagehide')));
+    await waitForSnapshot(page, '/prepaint/route-switching/dashboard');
+
+    await page.goto('/prepaint/route-switching/products', { waitUntil: 'networkidle' });
+    await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent('pagehide')));
+    await waitForSnapshot(page, '/prepaint/route-switching/products');
+
+    const routes = await page.evaluate(async () => {
+      return new Promise<string[]>((resolve) => {
+        const request = indexedDB.open('firsttx-prepaint', 2);
+        request.onerror = () => resolve([]);
+        request.onsuccess = () => {
+          const db = request.result;
+          const tx = db.transaction('snapshots', 'readonly');
+          const keysRequest = tx.objectStore('snapshots').getAllKeys();
+          keysRequest.onerror = () => {
+            db.close();
+            resolve([]);
+          };
+          keysRequest.onsuccess = () => {
+            const keys = keysRequest.result.map(String);
+            db.close();
+            resolve(keys);
+          };
+        };
+      });
+    });
+
+    expect(routes).toContain('/prepaint/route-switching/dashboard');
+    expect(routes).toContain('/prepaint/route-switching/products');
+  });
+
+  test('clears schema v1 snapshots before restore', async ({ page }) => {
+    let releaseBoot!: () => void;
+    const bootGate = new Promise<void>((resolve) => {
+      releaseBoot = resolve;
+    });
+
+    await page.route('**/firsttx-boot.js', async (route) => {
+      await bootGate;
+      await route.continue();
+    });
+
+    await page.goto('/prepaint/heavy', { waitUntil: 'commit' });
+
+    await page.evaluate(async () => {
+      await new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('firsttx-prepaint', 1);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          db.createObjectStore('snapshots', { keyPath: 'route' }).put({
+            route: '/prepaint/heavy',
+            timestamp: Date.now(),
+            body: '<div id="legacy-snapshot">Legacy</div>',
+            styles: [],
+          });
+        };
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          request.result.close();
+          resolve();
+        };
+      });
+    });
+
+    releaseBoot();
+    await page.waitForLoadState('networkidle');
+
+    const result = await page.evaluate(async () => {
+      return new Promise<{ version: number; snapshot: unknown }>((resolve, reject) => {
+        const request = indexedDB.open('firsttx-prepaint', 2);
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          const db = request.result;
+          const tx = db.transaction('snapshots', 'readonly');
+          const getRequest = tx.objectStore('snapshots').get('/prepaint/heavy');
+          getRequest.onerror = () => reject(getRequest.error);
+          getRequest.onsuccess = () => {
+            const value = { version: db.version, snapshot: getRequest.result ?? null };
+            db.close();
+            resolve(value);
+          };
+        };
+      });
+    });
+
+    expect(result).toEqual({ version: 2, snapshot: null });
+    await expect(page.locator('#legacy-snapshot')).toHaveCount(0);
   });
 });

--- a/apps/playground/vite.config.ts
+++ b/apps/playground/vite.config.ts
@@ -5,9 +5,40 @@ import tailwindcss from '@tailwindcss/vite';
 import { firstTx } from '@firsttx/prepaint/plugin/vite';
 
 const METRICS_BASE_URL = process.env.VITE_METRICS_BASE_URL ?? '';
+const PREPAINT_ROUTES = [
+  '/',
+  '/getting-started',
+  '/tour',
+  '/tour/problem',
+  '/tour/prepaint',
+  '/tour/local-first',
+  '/tour/tx',
+  '/tour/next',
+  '/prepaint/heavy',
+  '/prepaint/route-switching',
+  '/prepaint/route-switching/dashboard',
+  '/prepaint/route-switching/products',
+  '/prepaint/route-switching/analytics',
+  '/prepaint/route-switching/settings',
+  '/sync/instant-cart',
+  '/sync/timing',
+  '/sync/staleness',
+  '/sync/suspense',
+  '/tx/concurrent',
+  '/tx/rollback-chain',
+  '/tx/network-chaos',
+];
 
 export default defineConfig({
-  plugins: [react(), tailwindcss(), firstTx()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    firstTx({
+      policy: {
+        routes: PREPAINT_ROUTES,
+      },
+    }),
+  ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -72,11 +72,15 @@ pnpm add @firsttx/prepaint @firsttx/local-first @firsttx/tx
 import { firstTx } from '@firsttx/prepaint/plugin/vite';
 
 export default defineConfig({
-  plugins: [firstTx()],
+  plugins: [
+    firstTx({
+      policy: { routes: ['/dashboard', '/cart'] },
+    }),
+  ],
 });
 ```
 
-> 스냅샷 복원은 항상 React root 밖의 비상호작용 오버레이를 사용합니다. 기존 `overlay`, `overlayRoutes` 옵션은 deprecated no-op입니다.
+> `policy.routes`에 경로를 명시하기 전에는 Prepaint가 꺼져 있습니다. 스냅샷 복원은 항상 React root 밖의 비상호작용 오버레이를 사용합니다.
 
 ### 2. 진입점
 

--- a/docs/update-plan.md
+++ b/docs/update-plan.md
@@ -51,9 +51,11 @@
 - snapshot DOM을 container에 직접 삽입하고 hydrate하는 기존 경로는 제거하거나 한 릴리스 동안 명시적인 deprecated experimental 옵션으로만 유지합니다.
 - root child 수를 1개로 강제하는 guard를 제거합니다. Fragment와 복수 최상위 노드를 정상적인 React 출력으로 취급합니다.
 
-### 1-B. 저장·복원 보안 정책
+### 1-B. 저장·복원 보안 정책 — 완료 (2026-07-16)
 
-현재 기본 동작은 모든 route의 DOM과 같은 출처 CSS를 최대 7일간 저장합니다. CRM·대시보드 같은 권장 surface에서 PII가 IndexedDB에 남을 수 있습니다.
+변경 전 기본 동작은 모든 route의 DOM과 같은 출처 CSS를 최대 7일간 저장했습니다. CRM·대시보드 같은 권장 surface에서 PII가 IndexedDB에 남을 수 있었습니다.
+
+구현 결과는 `firstTx({ policy: { routes, ttlMs, maxSnapshotBytes, includeStyles } })`를 단일 정책 권위로 사용합니다. 경로를 누락하거나 비우면 캡처·복원을 비활성화하고, schema v2 migration과 boot-time prune으로 legacy·비허용·만료·크기 초과 record를 제거합니다. 기본 부트 경로는 self-starting external asset이며, `inline: true`는 CSP hash를 명시적으로 관리하는 경로입니다.
 
 - capture와 boot restore가 하나의 route allowlist 정책을 공유하도록 합니다.
 - allowlist 미설정 시 기본적으로 캡처와 복원을 비활성화합니다.

--- a/packages/prepaint/CHANGELOG.md
+++ b/packages/prepaint/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @firsttx/prepaint
 
+## Unreleased
+
+### Minor Changes
+
+- Add an explicit opt-in `policy` shared by capture, restore, and pruning. Missing or empty routes now disable Prepaint; defaults are a 7-day TTL, a 1 MiB UTF-8 payload limit, and CSS capture enabled.
+- Emit a self-starting `/firsttx-boot.js` asset by default. `inline: true` remains available for static deployments that manage a CSP hash.
+- Upgrade snapshot storage to schema v2, clearing legacy records once and pruning disallowed, expired, oversized, or style-ineligible records on boot.
+- Prepare snapshots during idle time and save on `visibilitychange`/`pagehide` without a `beforeunload` listener.
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/prepaint/README.md
+++ b/packages/prepaint/README.md
@@ -64,11 +64,11 @@ Prepaint currently provides a Vite plugin only.
 import { firstTx } from '@firsttx/prepaint/plugin/vite';
 
 export default defineConfig({
-  plugins: [firstTx()],
+  plugins: [firstTx({ policy: { routes: ['/dashboard', '/cart'] } })],
 });
 ```
 
-Snapshot restore always uses a non-interactive overlay outside the React root.
+Prepaint is disabled until `policy.routes` explicitly opts pathnames in. Matching is exact, and the same policy governs capture, restore, and stored-record pruning. Snapshot restore always uses a non-interactive overlay outside the React root.
 
 ### 2. React Entry
 
@@ -81,7 +81,7 @@ createFirstTxRoot(document.getElementById('root')!, <App />);
 
 **Done.** Prepaint now:
 
-- Captures snapshots on page lifecycle events
+- Prepares snapshots during idle time and saves a final state on hidden/pagehide
 - Replays a visual snapshot during boot on revisit
 - Hands control to the React app when the main bundle runs
 
@@ -93,16 +93,16 @@ createFirstTxRoot(document.getElementById('root')!, <App />);
 
 ```
 ┌─────────────────────────────────┐
-│ 1) Capture (on page leave)     │
-│  - beforeunload/pagehide/       │
-│    visibilitychange             │
+│ 1) Capture                     │
+│  - idle preparation             │
+│  - pagehide/visibilitychange    │
 │  - Saves DOM + styles to        │
 │    IndexedDB                    │
 └─────────────────────────────────┘
               ↓
 ┌─────────────────────────────────┐
 │ 2) Boot (measured on revisit)   │
-│  - Inline script runs           │
+│  - External script runs         │
 │  - Reads snapshot from IndexedDB│
 │  - Paints cached visual DOM     │
 └─────────────────────────────────┘
@@ -120,7 +120,9 @@ createFirstTxRoot(document.getElementById('root')!, <App />);
 - DB: `firsttx-prepaint`
 - Store: `snapshots`
 - Key: route pathname
-- TTL: 7 days
+- Default TTL: 7 days
+- Default maximum payload: 1 MiB
+- Schema v2 clears v1 records once, then every boot prunes records outside the current policy
 
 ---
 
@@ -151,16 +153,24 @@ createFirstTxRoot(
 
 ```typescript
 firstTx({
-  inline?: boolean,              // Inline boot script (default: true)
+  inline?: boolean,              // Inline boot script (default: false)
   minify?: boolean,              // Minify boot script (default: !isDev)
   injectTo?: 'head-prepend' | 'head' | 'body-prepend' | 'body',
   nonce?: string | (() => string),
+  policy: {
+    routes: string[],            // Exact pathnames; empty or omitted disables Prepaint
+    ttlMs?: number,              // Default: 7 days
+    maxSnapshotBytes?: number,   // Default: 1 MiB, UTF-8 JSON payload
+    includeStyles?: boolean,     // Default: true
+  },
 })
 ```
 
-For static Vite output, `nonce` is embedded at build time even when supplied as a function; it does not create a per-response nonce. Prefer an external boot asset or a CSP hash for static hosting.
+Static Vite output uses the self-starting `/firsttx-boot.js` asset by default. Set `inline: true` only when you intentionally manage a CSP hash for the generated inline script. A `nonce` is embedded at build time even when supplied as a function; static output cannot create a per-response nonce.
 
-The previous `overlay` and `overlayRoutes` options remain accepted as deprecated no-ops for one release. `setupCapture({ routes })` can restrict new captures; restore-side route filtering is not available in this release.
+The previous `overlay` and `overlayRoutes` options remain accepted as deprecated no-ops for one release. The Vite policy is serialized into the boot asset and reused by `setupCapture()`.
+
+Stored HTML is sanitized before overlay insertion. Passwords, marked sensitive fields, dangerous elements, event handlers, and executable URL schemes are removed. CSS is a visual cache, not sanitized application data: use `includeStyles: false` when routes can contain user-controlled or sensitive CSS, and only opt non-sensitive routes in.
 
 ---
 
@@ -399,7 +409,7 @@ A: Snapshot restore always uses an overlay outside the React root. No additional
 
 **Q: Can I restrict capture to certain routes?**
 
-A: Use `setupCapture()` manually or filter at app layer. Default captures all routes.
+A: Yes. Configure exact pathnames with `firstTx({ policy: { routes: [...] } })`. Missing or empty routes disable both capture and restore, and stale records are pruned.
 
 ---
 

--- a/packages/prepaint/src/boot.ts
+++ b/packages/prepaint/src/boot.ts
@@ -1,7 +1,8 @@
 declare const __FIRSTTX_DEV__: boolean;
 
-import { STORAGE_CONFIG, type Snapshot } from './types';
-import { openDB, resolveRouteKey } from './utils';
+import { isRouteAllowed, resolvePrepaintPolicy } from './policy';
+import { STORAGE_CONFIG, type PrepaintPolicy, type Snapshot } from './types';
+import { openDB, pruneSnapshots, resolveRouteKey } from './utils';
 import { mountOverlay } from './overlay';
 import { BootError, PrepaintStorageError, convertDOMException } from './errors';
 import { emitDevToolsEvent } from './devtools';
@@ -63,9 +64,10 @@ function deleteSnapshot(db: IDBDatabase, route: string): Promise<void> {
  * @throws Never throws - all errors are caught, logged, and recovered from.
  * The app will continue with a cold start if boot fails.
  */
-export async function boot(): Promise<void> {
+export async function boot(policy?: PrepaintPolicy | null): Promise<void> {
   const restoreStartTime = performance.now();
   const route = resolveRouteKey();
+  const resolvedPolicy = resolvePrepaintPolicy(policy);
   let db: IDBDatabase | null = null;
 
   try {
@@ -80,6 +82,30 @@ export async function boot(): Promise<void> {
 
     const bootError = new BootError('Failed to open IndexedDB', 'db-open', error as Error);
     console.error(bootError.getDebugInfo());
+    return;
+  }
+
+  try {
+    await pruneSnapshots(db, resolvedPolicy);
+  } catch (error) {
+    db.close();
+    emitDevToolsEvent('storage.error', {
+      operation: 'write',
+      code: error instanceof Error ? error.name : 'UNKNOWN',
+      recoverable: true,
+      route,
+    });
+    const bootError = new BootError(
+      'Failed to prune ineligible snapshots',
+      'snapshot-read',
+      error as Error,
+    );
+    console.error(bootError.getDebugInfo());
+    return;
+  }
+
+  if (!resolvedPolicy || !isRouteAllowed(resolvedPolicy, route)) {
+    db.close();
     return;
   }
 
@@ -122,7 +148,7 @@ export async function boot(): Promise<void> {
   if (
     typeof snapshot.timestamp !== 'number' ||
     typeof snapshot.body !== 'string' ||
-    typeof snapshot.route !== 'string'
+    snapshot.route !== route
   ) {
     try {
       const db2 = await openDB();
@@ -140,7 +166,7 @@ export async function boot(): Promise<void> {
   }
 
   const age = Date.now() - snapshot.timestamp;
-  if (age > STORAGE_CONFIG.MAX_SNAPSHOT_AGE) {
+  if (age > resolvedPolicy.ttlMs) {
     emitDevToolsEvent('restore', {
       route,
       strategy: 'cold-start',
@@ -149,14 +175,14 @@ export async function boot(): Promise<void> {
     });
     if (typeof __FIRSTTX_DEV__ !== 'undefined' && __FIRSTTX_DEV__) {
       console.log(
-        `[FirstTx] Snapshot too old (age: ${age}ms, max: ${STORAGE_CONFIG.MAX_SNAPSHOT_AGE}ms), skipping restore`,
+        `[FirstTx] Snapshot too old (age: ${age}ms, max: ${resolvedPolicy.ttlMs}ms), skipping restore`,
       );
     }
     return;
   }
 
   try {
-    mountOverlay(snapshot.body, snapshot.styles);
+    mountOverlay(snapshot.body, resolvedPolicy.includeStyles ? snapshot.styles : undefined);
     document.documentElement.setAttribute('data-prepaint', 'true');
     document.documentElement.setAttribute('data-prepaint-overlay', 'true');
     document.documentElement.setAttribute('data-prepaint-timestamp', String(snapshot.timestamp));

--- a/packages/prepaint/src/capture.ts
+++ b/packages/prepaint/src/capture.ts
@@ -1,8 +1,14 @@
 declare const __FIRSTTX_DEV__: boolean;
 
 import { DANGEROUS_ATTRIBUTES } from '@firsttx/shared';
-import { STORAGE_CONFIG, type Snapshot, type SnapshotStyle } from './types';
-import { openDB, resolveRouteKey, scrubSensitiveFields } from './utils';
+import {
+  getSnapshotPayloadBytes,
+  isRouteAllowed,
+  resolvePrepaintPolicy,
+  type ResolvedPrepaintPolicy,
+} from './policy';
+import { STORAGE_CONFIG, type PrepaintPolicy, type Snapshot, type SnapshotStyle } from './types';
+import { openDB, pruneStoredSnapshots, resolveRouteKey, scrubSensitiveFields } from './utils';
 import { CaptureError, PrepaintStorageError, convertDOMException } from './errors';
 import { emitDevToolsEvent } from './devtools';
 
@@ -199,9 +205,11 @@ function serializeRoot(rootEl: HTMLElement): string {
  * }
  * ```
  */
-export async function captureSnapshot(): Promise<Snapshot | null> {
+export async function captureSnapshot(policy?: PrepaintPolicy | null): Promise<Snapshot | null> {
   const captureStartTime = performance.now();
   const route = resolveRouteKey();
+  const resolvedPolicy = resolvePrepaintPolicy(policy);
+  if (!resolvedPolicy || !isRouteAllowed(resolvedPolicy, route)) return null;
 
   let root: HTMLElement | null = null;
   let body: string;
@@ -226,7 +234,7 @@ export async function captureSnapshot(): Promise<Snapshot | null> {
 
   let styles: SnapshotStyle[];
   try {
-    styles = await collectStyles();
+    styles = resolvedPolicy.includeStyles ? await collectStyles() : [];
   } catch (error) {
     const captureError = new CaptureError(
       'Failed to collect styles',
@@ -246,6 +254,15 @@ export async function captureSnapshot(): Promise<Snapshot | null> {
     timestamp: Date.now(),
     styles: styles.length > 0 ? styles : undefined,
   };
+
+  if (getSnapshotPayloadBytes(snapshot) > resolvedPolicy.maxSnapshotBytes) {
+    if (typeof __FIRSTTX_DEV__ !== 'undefined' && __FIRSTTX_DEV__) {
+      console.warn(
+        `[FirstTx] Snapshot exceeds ${resolvedPolicy.maxSnapshotBytes} bytes for ${route}`,
+      );
+    }
+    return null;
+  }
 
   let db: IDBDatabase | null = null;
   try {
@@ -293,7 +310,8 @@ export async function captureSnapshot(): Promise<Snapshot | null> {
  * Options for configuring automatic snapshot capture.
  */
 export interface SetupCaptureOptions {
-  /** Limit capture to specific routes. If omitted, all routes are captured. */
+  policy?: PrepaintPolicy | null;
+  /** @deprecated Configure `policy.routes` in the Vite plugin. */
   routes?: string[];
   /** Callback invoked after each successful capture. */
   onCapture?: (snapshot: Snapshot) => void;
@@ -303,13 +321,22 @@ let captureInitialized = false;
 let captureOptions: SetupCaptureOptions | undefined = undefined;
 let captureCleanup: (() => void) | null = null;
 
+type IdleWindow = Window & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+function resolveCapturePolicy(options?: SetupCaptureOptions): ResolvedPrepaintPolicy | null {
+  if (options?.policy !== undefined) return resolvePrepaintPolicy(options.policy);
+  if (options?.routes !== undefined) return resolvePrepaintPolicy({ routes: options.routes });
+  return resolvePrepaintPolicy();
+}
+
 /**
- * Registers event listeners to automatically capture snapshots when the page
- * is about to be hidden or unloaded.
+ * Registers event listeners to prepare snapshots while idle and persist the
+ * latest visual state when the page is hidden.
  *
- * This function sets up listeners for `visibilitychange`, `pagehide`, and
- * `beforeunload` events to trigger snapshot capture at the optimal moment
- * (when the user navigates away or switches tabs).
+ * This function uses idle time plus `visibilitychange` and `pagehide`.
  *
  * @param options - Configuration options for capture behavior
  * @returns A cleanup function that removes all registered listeners
@@ -320,7 +347,7 @@ let captureCleanup: (() => void) | null = null;
  * import { setupCapture } from '@firsttx/prepaint';
  *
  * const cleanup = setupCapture({
- *   routes: ['/dashboard', '/profile'],
+ *   policy: { routes: ['/dashboard', '/profile'] },
  *   onCapture: (snapshot) => {
  *     console.log('Snapshot saved:', snapshot.route);
  *   },
@@ -332,47 +359,80 @@ let captureCleanup: (() => void) | null = null;
  *
  * @remarks
  * - Only one capture listener set is registered per page.
- * - Subsequent calls update options (routes/onCapture) and reuse existing listeners.
- * - Captures are debounced using `queueMicrotask` to prevent duplicates.
+ * - Subsequent calls update options and reuse existing listeners.
+ * - Captures are deduplicated while a write is in flight.
  * - The cleanup function resets the initialization flag, allowing re-setup.
  */
 export function setupCapture(options?: SetupCaptureOptions): () => void {
   captureOptions = options;
+  const initialPolicy = resolveCapturePolicy(options);
+  void pruneStoredSnapshots(initialPolicy).catch(() => {});
+
+  if (!initialPolicy) {
+    captureCleanup?.();
+    return () => {};
+  }
+
   if (captureCleanup) return captureCleanup;
 
   captureInitialized = true;
-  let scheduled = false;
+  let captureInFlight: Promise<void> | null = null;
+  let idleHandle: number | null = null;
+  const idleWindow = window as IdleWindow;
+
   const maybeSave = () => {
-    if (scheduled) return;
-    scheduled = true;
-    queueMicrotask(() => {
-      scheduled = false;
-      const route = window.location.pathname;
-      const activeOptions = captureOptions;
-      if (activeOptions?.routes && !activeOptions.routes.includes(route)) return;
-      void captureSnapshot().then((snapshot) => {
+    if (captureInFlight) return;
+    const activeOptions = captureOptions;
+    const activePolicy = resolveCapturePolicy(activeOptions);
+    if (!activePolicy || !isRouteAllowed(activePolicy, resolveRouteKey())) return;
+
+    captureInFlight = captureSnapshot(activePolicy)
+      .then((snapshot) => {
         if (snapshot) activeOptions?.onCapture?.(snapshot);
+      })
+      .finally(() => {
+        captureInFlight = null;
       });
-    });
   };
-  const onHidden = () => {
-    if (document.visibilityState === 'hidden') maybeSave();
+
+  const scheduleIdleCapture = () => {
+    if (idleHandle !== null) return;
+    const run = () => {
+      idleHandle = null;
+      maybeSave();
+    };
+    idleHandle = idleWindow.requestIdleCallback
+      ? idleWindow.requestIdleCallback(run, { timeout: STORAGE_CONFIG.IDLE_CAPTURE_TIMEOUT })
+      : window.setTimeout(run, STORAGE_CONFIG.IDLE_CAPTURE_TIMEOUT);
   };
-  document.addEventListener('visibilitychange', onHidden, { capture: true });
+
+  const onVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      maybeSave();
+      return;
+    }
+    scheduleIdleCapture();
+  };
+
+  const onPageShow = () => scheduleIdleCapture();
+
+  document.addEventListener('visibilitychange', onVisibilityChange, { capture: true });
   window.addEventListener('pagehide', maybeSave, { capture: true });
-  const onBeforeUnload = () => {
-    maybeSave();
-  };
-  window.addEventListener('beforeunload', onBeforeUnload);
+  window.addEventListener('pageshow', onPageShow, { capture: true });
+  scheduleIdleCapture();
 
   captureCleanup = () => {
     if (!captureInitialized) return;
     captureInitialized = false;
     captureOptions = undefined;
-    scheduled = false;
-    document.removeEventListener('visibilitychange', onHidden, { capture: true });
+    if (idleHandle !== null) {
+      if (idleWindow.cancelIdleCallback) idleWindow.cancelIdleCallback(idleHandle);
+      else window.clearTimeout(idleHandle);
+      idleHandle = null;
+    }
+    document.removeEventListener('visibilitychange', onVisibilityChange, { capture: true });
     window.removeEventListener('pagehide', maybeSave, { capture: true });
-    window.removeEventListener('beforeunload', onBeforeUnload);
+    window.removeEventListener('pageshow', onPageShow, { capture: true });
     captureCleanup = null;
   };
 

--- a/packages/prepaint/src/index.ts
+++ b/packages/prepaint/src/index.ts
@@ -14,3 +14,4 @@ export {
 
 export type { HandoffStrategy } from './handoff';
 export type { CreateFirstTxRootOptions } from './helpers';
+export type { PrepaintPolicy } from './types';

--- a/packages/prepaint/src/plugin/vite.ts
+++ b/packages/prepaint/src/plugin/vite.ts
@@ -2,12 +2,15 @@ import type { Plugin } from 'vite';
 import { build } from 'esbuild';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { serializePrepaintPolicy } from '../policy';
+import type { PrepaintPolicy } from '../types';
 
 export interface FirstTxPluginOptions {
   inline?: boolean;
   minify?: boolean;
   injectTo?: 'head' | 'head-prepend' | 'body' | 'body-prepend';
   nonce?: string | (() => string);
+  policy?: PrepaintPolicy;
   /** @deprecated Snapshot restore always uses an overlay. */
   overlay?: boolean;
   /** @deprecated Snapshot restore always uses an overlay. */
@@ -19,21 +22,26 @@ const NONCE_PATTERN = /^[A-Za-z0-9+/_-]+=*$/;
 
 export function firstTx(options: FirstTxPluginOptions = {}): Plugin {
   const {
-    inline = true,
+    inline = false,
     minify: userMinify,
     injectTo = 'head-prepend',
     nonce,
     devFlagOverride,
   } = options;
+  const serializedPolicy = serializePrepaintPolicy(options.policy);
 
   let bootScriptCode: string | null = null;
   let isDev = false;
+  let isBuild = false;
+  let base = '/';
 
   return {
     name: 'vite-plugin-firsttx',
     configResolved(config) {
       isDev =
         typeof devFlagOverride === 'boolean' ? devFlagOverride : config.mode === 'development';
+      isBuild = config.command === 'build';
+      base = config.base || '/';
     },
     async buildStart() {
       const minify = userMinify ?? !isDev;
@@ -58,6 +66,13 @@ export function firstTx(options: FirstTxPluginOptions = {}): Plugin {
         });
         if (result.outputFiles && result.outputFiles[0]) {
           bootScriptCode = result.outputFiles[0].text;
+          if (!inline && isBuild && this?.emitFile) {
+            this.emitFile({
+              type: 'asset',
+              fileName: 'firsttx-boot.js',
+              source: createExecutableBootScript(bootScriptCode, serializedPolicy),
+            });
+          }
         }
       } catch (error) {
         console.error('[FirstTx] Failed to build boot script:', error);
@@ -71,23 +86,32 @@ export function firstTx(options: FirstTxPluginOptions = {}): Plugin {
         const nonceValue = resolveAndValidateNonce(nonce);
 
         if (inline) {
-          const bootTag = `<script${nonceValue ? ` nonce="${nonceValue}"` : ''}>try{${bootScriptCode};__firsttx_boot__.boot();}catch(e){console.error('[FirstTx] Boot script failed:',e);}</script>`;
+          const executableCode = createExecutableBootScript(bootScriptCode, serializedPolicy);
+          const bootTag = `<script${nonceValue ? ` nonce="${nonceValue}"` : ''}>${executableCode}</script>`;
           return injectScript(html, bootTag, injectTo);
         } else {
-          const bootTag = `<script${nonceValue ? ` nonce="${nonceValue}"` : ''} src="/firsttx-boot.js"></script>`;
+          const bootTag = `<script vite-ignore${nonceValue ? ` nonce="${nonceValue}"` : ''} src="${base}firsttx-boot.js"></script>`;
           return injectScript(html, bootTag, injectTo);
         }
       },
     },
-    resolveId(id) {
-      if (!inline && id === '/firsttx-boot.js') return id;
-    },
-    load(id) {
-      if (!inline && id === '/firsttx-boot.js' && bootScriptCode) {
-        return { code: bootScriptCode, map: null };
-      }
+    configureServer(server) {
+      if (inline) return;
+      server.middlewares.use('/firsttx-boot.js', (_request, response, next) => {
+        if (!bootScriptCode) {
+          next();
+          return;
+        }
+        response.statusCode = 200;
+        response.setHeader('Content-Type', 'text/javascript; charset=utf-8');
+        response.end(createExecutableBootScript(bootScriptCode, serializedPolicy));
+      });
     },
   };
+}
+
+function createExecutableBootScript(bootScriptCode: string, serializedPolicy: string): string {
+  return `${bootScriptCode};try{globalThis.__FIRSTTX_PREPAINT_POLICY__=${serializedPolicy};__firsttx_boot__.boot(globalThis.__FIRSTTX_PREPAINT_POLICY__);}catch(e){console.error('[FirstTx] Boot script failed:',e);}`;
 }
 
 function resolveAndValidateNonce(nonceOption: FirstTxPluginOptions['nonce']): string | undefined {

--- a/packages/prepaint/src/policy.ts
+++ b/packages/prepaint/src/policy.ts
@@ -1,0 +1,155 @@
+import { STORAGE_CONFIG, type PrepaintPolicy, type Snapshot } from './types';
+
+export interface ResolvedPrepaintPolicy {
+  routes: string[];
+  ttlMs: number;
+  maxSnapshotBytes: number;
+  includeStyles: boolean;
+}
+
+type PolicyParseResult = {
+  value: ResolvedPrepaintPolicy | null;
+  error: string | null;
+};
+
+type PrepaintGlobal = typeof globalThis & {
+  __FIRSTTX_PREPAINT_POLICY__?: unknown;
+};
+
+function parsePolicy(policy: unknown): PolicyParseResult {
+  if (policy === undefined || policy === null) {
+    return { value: null, error: null };
+  }
+
+  if (typeof policy !== 'object') {
+    return { value: null, error: 'policy must be an object' };
+  }
+
+  const candidate = policy as Partial<PrepaintPolicy>;
+  if (!Array.isArray(candidate.routes)) {
+    return { value: null, error: 'routes must be an array' };
+  }
+
+  const routes: string[] = [];
+  for (const route of candidate.routes) {
+    if (typeof route !== 'string' || !route.startsWith('/')) {
+      return { value: null, error: 'every route must be an absolute pathname' };
+    }
+    if (!routes.includes(route)) routes.push(route);
+  }
+
+  if (routes.length === 0) {
+    return { value: null, error: null };
+  }
+
+  const ttlMs = candidate.ttlMs ?? STORAGE_CONFIG.MAX_SNAPSHOT_AGE;
+  if (typeof ttlMs !== 'number' || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+    return { value: null, error: 'ttlMs must be a positive finite number' };
+  }
+
+  const maxSnapshotBytes = candidate.maxSnapshotBytes ?? STORAGE_CONFIG.MAX_SNAPSHOT_BYTES;
+  if (
+    typeof maxSnapshotBytes !== 'number' ||
+    !Number.isSafeInteger(maxSnapshotBytes) ||
+    maxSnapshotBytes <= 0
+  ) {
+    return { value: null, error: 'maxSnapshotBytes must be a positive safe integer' };
+  }
+
+  const includeStyles = candidate.includeStyles ?? true;
+  if (typeof includeStyles !== 'boolean') {
+    return { value: null, error: 'includeStyles must be a boolean' };
+  }
+
+  return {
+    value: {
+      routes,
+      ttlMs,
+      maxSnapshotBytes,
+      includeStyles,
+    },
+    error: null,
+  };
+}
+
+export function normalizePrepaintPolicy(policy: unknown): ResolvedPrepaintPolicy | null {
+  return parsePolicy(policy).value;
+}
+
+export function validatePrepaintPolicy(policy: unknown): ResolvedPrepaintPolicy | null {
+  const result = parsePolicy(policy);
+  if (result.error) {
+    throw new Error(`[FirstTx] Invalid prepaint policy: ${result.error}`);
+  }
+  return result.value;
+}
+
+export function setGlobalPrepaintPolicy(policy: unknown): ResolvedPrepaintPolicy | null {
+  const resolved = normalizePrepaintPolicy(policy);
+  (globalThis as PrepaintGlobal).__FIRSTTX_PREPAINT_POLICY__ = resolved;
+  return resolved;
+}
+
+export function resolvePrepaintPolicy(
+  policy?: PrepaintPolicy | null,
+): ResolvedPrepaintPolicy | null {
+  if (policy !== undefined) {
+    return setGlobalPrepaintPolicy(policy);
+  }
+  return normalizePrepaintPolicy((globalThis as PrepaintGlobal).__FIRSTTX_PREPAINT_POLICY__);
+}
+
+export function isRouteAllowed(policy: ResolvedPrepaintPolicy | null, route: string): boolean {
+  return policy?.routes.includes(route) ?? false;
+}
+
+function utf8ByteLength(value: string): number {
+  if (typeof TextEncoder === 'function') {
+    return new TextEncoder().encode(value).byteLength;
+  }
+  if (typeof Blob === 'function') {
+    return new Blob([value]).size;
+  }
+  return encodeURIComponent(value).replace(/%[0-9A-F]{2}|./g, 'x').length;
+}
+
+export function getSnapshotPayloadBytes(snapshot: Pick<Snapshot, 'body' | 'styles'>): number {
+  return utf8ByteLength(
+    JSON.stringify({
+      body: snapshot.body,
+      styles: snapshot.styles ?? [],
+    }),
+  );
+}
+
+export function shouldPruneSnapshot(
+  value: unknown,
+  policy: ResolvedPrepaintPolicy | null,
+  now = Date.now(),
+): boolean {
+  if (!policy || !value || typeof value !== 'object') return true;
+
+  const snapshot = value as Partial<Snapshot>;
+  if (
+    typeof snapshot.route !== 'string' ||
+    typeof snapshot.body !== 'string' ||
+    typeof snapshot.timestamp !== 'number'
+  ) {
+    return true;
+  }
+
+  if (!isRouteAllowed(policy, snapshot.route)) return true;
+  if (now - snapshot.timestamp > policy.ttlMs) return true;
+  if (getSnapshotPayloadBytes(snapshot as Snapshot) > policy.maxSnapshotBytes) return true;
+  if (!policy.includeStyles && (snapshot.styles?.length ?? 0) > 0) return true;
+  return false;
+}
+
+export function serializePrepaintPolicy(policy: unknown): string {
+  return JSON.stringify(validatePrepaintPolicy(policy))
+    .replace(/&/g, '\\u0026')
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}

--- a/packages/prepaint/src/sanitize.ts
+++ b/packages/prepaint/src/sanitize.ts
@@ -42,7 +42,7 @@ function fallbackSanitize(html: string): string {
         el.removeAttribute(attr.name);
         return;
       }
-      const value = attr.value.toLowerCase().trim();
+      const value = attr.value.toLowerCase().replace(/[\u0000-\u0020]+/g, '');
       if (value.startsWith('javascript:') || value.startsWith('data:text/html')) {
         el.removeAttribute(attr.name);
       }

--- a/packages/prepaint/src/types.ts
+++ b/packages/prepaint/src/types.ts
@@ -1,11 +1,19 @@
 export const STORAGE_CONFIG = {
   DB_NAME: 'firsttx-prepaint',
-  DB_VERSION: 1,
+  DB_VERSION: 2,
   STORE_SNAPSHOTS: 'snapshots',
   MAX_SNAPSHOT_AGE: 7 * 24 * 60 * 60 * 1000,
-  /** Timeout for fetching external stylesheets during capture (5 seconds) */
+  MAX_SNAPSHOT_BYTES: 1024 * 1024,
   STYLE_FETCH_TIMEOUT: 5000,
+  IDLE_CAPTURE_TIMEOUT: 2000,
 } as const;
+
+export interface PrepaintPolicy {
+  routes: readonly string[];
+  ttlMs?: number;
+  maxSnapshotBytes?: number;
+  includeStyles?: boolean;
+}
 
 export interface Snapshot {
   route: string;

--- a/packages/prepaint/src/utils.ts
+++ b/packages/prepaint/src/utils.ts
@@ -1,3 +1,4 @@
+import { shouldPruneSnapshot, type ResolvedPrepaintPolicy } from './policy';
 import { STORAGE_CONFIG } from './types';
 
 export function openDB(): Promise<IDBDatabase> {
@@ -17,11 +18,52 @@ export function openDB(): Promise<IDBDatabase> {
 
     request.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result;
+      let store: IDBObjectStore;
       if (!db.objectStoreNames.contains(STORAGE_CONFIG.STORE_SNAPSHOTS)) {
-        db.createObjectStore(STORAGE_CONFIG.STORE_SNAPSHOTS, { keyPath: 'route' });
+        store = db.createObjectStore(STORAGE_CONFIG.STORE_SNAPSHOTS, { keyPath: 'route' });
+      } else {
+        store = request.transaction!.objectStore(STORAGE_CONFIG.STORE_SNAPSHOTS);
+      }
+      if (event.oldVersion > 0 && event.oldVersion < STORAGE_CONFIG.DB_VERSION) {
+        store.clear();
       }
     };
   });
+}
+
+export function pruneSnapshots(
+  db: IDBDatabase,
+  policy: ResolvedPrepaintPolicy | null,
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORAGE_CONFIG.STORE_SNAPSHOTS, 'readwrite');
+    const store = tx.objectStore(STORAGE_CONFIG.STORE_SNAPSHOTS);
+    const request = store.openCursor();
+    let deleted = 0;
+
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (!cursor) return;
+      if (shouldPruneSnapshot(cursor.value, policy)) {
+        cursor.delete();
+        deleted += 1;
+      }
+      cursor.continue();
+    };
+    request.onerror = () => reject(request.error ?? new Error('Failed to scan snapshots'));
+    tx.oncomplete = () => resolve(deleted);
+    tx.onerror = () => reject(tx.error ?? new Error('Failed to prune snapshots'));
+    tx.onabort = () => reject(tx.error ?? new Error('Snapshot prune aborted'));
+  });
+}
+
+export async function pruneStoredSnapshots(policy: ResolvedPrepaintPolicy | null): Promise<number> {
+  const db = await openDB();
+  try {
+    return await pruneSnapshots(db, policy);
+  } finally {
+    db.close();
+  }
 }
 
 /**

--- a/packages/prepaint/tests/boot.test.ts
+++ b/packages/prepaint/tests/boot.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { boot } from '../src/boot';
 import { openDB } from '../src/utils';
-import { STORAGE_CONFIG, type Snapshot } from '../src/types';
+import { STORAGE_CONFIG, type PrepaintPolicy, type Snapshot } from '../src/types';
+
+const TEST_POLICY = {
+  routes: ['/', '/cart'],
+} satisfies PrepaintPolicy;
 
 describe('boot', () => {
   let db: IDBDatabase | null = null;
@@ -43,6 +47,19 @@ describe('boot', () => {
     });
   }
 
+  async function readSnapshot(route: string): Promise<Snapshot | undefined> {
+    const readDb = await openDB();
+    const tx = readDb.transaction(STORAGE_CONFIG.STORE_SNAPSHOTS, 'readonly');
+    const store = tx.objectStore(STORAGE_CONFIG.STORE_SNAPSHOTS);
+    const snapshot = await new Promise<Snapshot | undefined>((resolve) => {
+      const request = store.get(route) as IDBRequest<Snapshot>;
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => resolve(undefined);
+    });
+    readDb.close();
+    return snapshot;
+  }
+
   function mountRoot(inner = '') {
     document.body.innerHTML = `<div id="root">${inner}</div>`;
   }
@@ -56,7 +73,7 @@ describe('boot', () => {
       styles: [],
     };
     await saveSnapshot(snapshot);
-    await boot();
+    await boot(TEST_POLICY);
     const overlay = document.getElementById('__firsttx_prepaint__');
     expect(overlay?.shadowRoot?.querySelector('#test-content')?.textContent).toBe('Hello World');
     expect(document.getElementById('root')!.innerHTML).toBe(
@@ -69,9 +86,39 @@ describe('boot', () => {
   it('does nothing when snapshot does not exist', async () => {
     mountRoot('<div>Original</div>');
     const original = document.getElementById('root')!.innerHTML;
-    await boot();
+    await boot(TEST_POLICY);
     expect(document.getElementById('root')!.innerHTML).toBe(original);
     expect(document.documentElement.hasAttribute('data-prepaint')).toBe(false);
+  });
+
+  it('defaults to off and removes stored snapshots when policy is missing', async () => {
+    mountRoot('<div>Current</div>');
+    await saveSnapshot({
+      route: '/',
+      timestamp: Date.now(),
+      body: '<div>Stored</div>',
+      styles: [],
+    });
+
+    await boot(null);
+
+    expect(document.getElementById('__firsttx_prepaint__')).toBeNull();
+    expect(await readSnapshot('/')).toBeUndefined();
+  });
+
+  it('prunes snapshots outside the exact route allowlist', async () => {
+    mountRoot('<div>Current</div>');
+    await saveSnapshot({
+      route: '/',
+      timestamp: Date.now(),
+      body: '<div>Stored</div>',
+      styles: [],
+    });
+
+    await boot({ routes: ['/cart'] });
+
+    expect(document.getElementById('__firsttx_prepaint__')).toBeNull();
+    expect(await readSnapshot('/')).toBeUndefined();
   });
 
   it('does not inject expired snapshot', async () => {
@@ -84,9 +131,24 @@ describe('boot', () => {
       styles: [],
     };
     await saveSnapshot(snapshot);
-    await boot();
+    await boot(TEST_POLICY);
     expect(document.getElementById('root')!.innerHTML).toBe('<div>Current</div>');
     expect(document.documentElement.hasAttribute('data-prepaint')).toBe(false);
+  });
+
+  it('uses the configured TTL when pruning snapshots', async () => {
+    mountRoot('<div>Current</div>');
+    await saveSnapshot({
+      route: '/',
+      timestamp: Date.now() - 2_000,
+      body: '<div>Expired by policy</div>',
+      styles: [],
+    });
+
+    await boot({ routes: ['/'], ttlMs: 1_000 });
+
+    expect(document.getElementById('__firsttx_prepaint__')).toBeNull();
+    expect(await readSnapshot('/')).toBeUndefined();
   });
 
   it('injects styles into the overlay shadow root', async () => {
@@ -101,13 +163,43 @@ describe('boot', () => {
       ],
     };
     await saveSnapshot(snapshot);
-    await boot();
+    await boot(TEST_POLICY);
     const els = Array.from(
       document.getElementById('__firsttx_prepaint__')!.shadowRoot!.querySelectorAll('style'),
     );
     const texts = els.map((e) => e.textContent);
     expect(texts).toContain('.test { color: red; }');
     expect(texts).toContain('.another { font-size: 16px; }');
+  });
+
+  it('prunes styled snapshots when styles are disabled', async () => {
+    mountRoot('<div>Current</div>');
+    await saveSnapshot({
+      route: '/',
+      timestamp: Date.now(),
+      body: '<div>Stored</div>',
+      styles: [{ type: 'inline', content: '.stored { color: red; }' }],
+    });
+
+    await boot({ routes: ['/'], includeStyles: false });
+
+    expect(document.getElementById('__firsttx_prepaint__')).toBeNull();
+    expect(await readSnapshot('/')).toBeUndefined();
+  });
+
+  it('prunes snapshots larger than the configured byte limit', async () => {
+    mountRoot('<div>Current</div>');
+    await saveSnapshot({
+      route: '/',
+      timestamp: Date.now(),
+      body: '<div>Stored content</div>',
+      styles: [],
+    });
+
+    await boot({ routes: ['/'], maxSnapshotBytes: 8 });
+
+    expect(document.getElementById('__firsttx_prepaint__')).toBeNull();
+    expect(await readSnapshot('/')).toBeUndefined();
   });
 
   it('normalizes legacy string snapshot styles', async () => {
@@ -119,7 +211,7 @@ describe('boot', () => {
       styles: ['.legacy { display: block; }'],
     };
     await saveSnapshot(snapshot);
-    await boot();
+    await boot(TEST_POLICY);
     const texts = Array.from(
       document.getElementById('__firsttx_prepaint__')!.shadowRoot!.querySelectorAll('style'),
     ).map((node) => node.textContent);
@@ -136,7 +228,7 @@ describe('boot', () => {
       styles: [],
     };
     await saveSnapshot(snapshot);
-    await boot();
+    await boot(TEST_POLICY);
     expect(document.documentElement.getAttribute('data-prepaint-timestamp')).toBe(
       String(timestamp),
     );
@@ -153,7 +245,7 @@ describe('boot', () => {
       styles: [],
     };
     await saveSnapshot(snapshot);
-    await boot();
+    await boot(TEST_POLICY);
     expect(document.getElementById('__firsttx_prepaint__')?.shadowRoot?.textContent).toContain(
       'Cart Content',
     );
@@ -170,7 +262,7 @@ describe('boot', () => {
       styles: [{ type: 'inline', content: '.x{opacity:1;}' }],
     };
     await saveSnapshot(snapshot);
-    await boot();
+    await boot(TEST_POLICY);
     expect(document.getElementById('__firsttx_prepaint__')).toBeTruthy();
     expect(document.documentElement.getAttribute('data-prepaint')).toBe('true');
     expect(document.documentElement.getAttribute('data-prepaint-overlay')).toBe('true');
@@ -184,7 +276,7 @@ describe('boot', () => {
         throw new Error('DB Error');
       });
 
-      await boot();
+      await boot(TEST_POLICY);
 
       expect(spy).toHaveBeenCalled();
       const errorCall = spy.mock.calls[0][0] as string;
@@ -211,7 +303,7 @@ describe('boot', () => {
       });
       db.close();
 
-      await boot();
+      await boot(TEST_POLICY);
 
       expect(document.documentElement.hasAttribute('data-prepaint')).toBe(false);
 
@@ -235,7 +327,7 @@ describe('boot', () => {
       });
       db.close();
 
-      await boot();
+      await boot(TEST_POLICY);
 
       const db2 = await openDB();
       const tx2 = db2.transaction(STORAGE_CONFIG.STORE_SNAPSHOTS, 'readonly');
@@ -269,7 +361,7 @@ describe('boot', () => {
         throw new Error('attachShadow failed');
       });
 
-      await boot();
+      await boot(TEST_POLICY);
 
       expect(spy).toHaveBeenCalled();
       const errorCall = spy.mock.calls[0][0] as string;
@@ -287,7 +379,7 @@ describe('boot', () => {
         throw new Error('Complete failure');
       });
 
-      await expect(boot()).resolves.not.toThrow();
+      await expect(boot(TEST_POLICY)).resolves.not.toThrow();
     });
   });
 });

--- a/packages/prepaint/tests/capture.test.ts
+++ b/packages/prepaint/tests/capture.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setupCapture, captureSnapshot } from '../src/capture';
 import * as utilsModule from '../src/utils';
-import type { Snapshot } from '../src/types';
+import type { PrepaintPolicy, Snapshot } from '../src/types';
+
+const TEST_POLICY = {
+  routes: ['/', '/allowed', '/blocked', '/products', '/custom-key'],
+} satisfies PrepaintPolicy;
 
 const tick = () => Promise.resolve();
 
@@ -76,28 +80,52 @@ describe('setupCapture', () => {
     }
   });
 
-  it('registers visibilitychange, pagehide, beforeunload listeners', () => {
+  it('registers visibilitychange, pagehide, and pageshow without beforeunload', () => {
     const addWin = vi.spyOn(window, 'addEventListener');
     const addDoc = vi.spyOn(document, 'addEventListener');
-    cleanup = setupCapture();
+    cleanup = setupCapture({ policy: TEST_POLICY });
     const winEvents = addWin.mock.calls.map((c) => c[0]);
     const docEvents = addDoc.mock.calls.map((c) => c[0]);
     expect(winEvents).toContain('pagehide');
-    expect(winEvents).toContain('beforeunload');
+    expect(winEvents).toContain('pageshow');
+    expect(winEvents).not.toContain('beforeunload');
     expect(docEvents).toContain('visibilitychange');
+  });
+
+  it('prepares a snapshot through requestIdleCallback', async () => {
+    let idleCallback: (() => void) | undefined;
+    const requestIdleCallback = vi.fn((callback: () => void) => {
+      idleCallback = callback;
+      return 1;
+    });
+    Object.defineProperty(window, 'requestIdleCallback', {
+      configurable: true,
+      value: requestIdleCallback,
+    });
+
+    cleanup = setupCapture({ policy: TEST_POLICY });
+    expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), { timeout: 2_000 });
+
+    idleCallback?.();
+    await tick();
+    await tick();
+
+    expect(getSnapshot('/')).toBeDefined();
+    Reflect.deleteProperty(window, 'requestIdleCallback');
   });
 
   it('is idempotent and returns noop cleanup on duplicate call', () => {
     const addWin = vi.spyOn(window, 'addEventListener');
     const addDoc = vi.spyOn(document, 'addEventListener');
-    const c1 = setupCapture();
-    const c2 = setupCapture();
+    const c1 = setupCapture({ policy: TEST_POLICY });
+    const c2 = setupCapture({ policy: TEST_POLICY });
     cleanup = c1;
     const winEvents = addWin.mock.calls.map((c) => c[0]);
     const docEvents = addDoc.mock.calls.map((c) => c[0]);
     const count = (arr: unknown[], ev: string) => arr.filter((x) => x === ev).length;
-    expect(count(winEvents, 'beforeunload')).toBe(1);
+    expect(count(winEvents, 'beforeunload')).toBe(0);
     expect(count(winEvents, 'pagehide')).toBe(1);
+    expect(count(winEvents, 'pageshow')).toBe(1);
     expect(count(docEvents, 'visibilitychange')).toBe(1);
     expect(typeof c2).toBe('function');
   });
@@ -105,13 +133,14 @@ describe('setupCapture', () => {
   it('cleans up all listeners on cleanup call', () => {
     const removeWin = vi.spyOn(window, 'removeEventListener');
     const removeDoc = vi.spyOn(document, 'removeEventListener');
-    cleanup = setupCapture();
+    cleanup = setupCapture({ policy: TEST_POLICY });
     cleanup();
     cleanup = null;
     const winEvents = removeWin.mock.calls.map((c) => c[0]);
     const docEvents = removeDoc.mock.calls.map((c) => c[0]);
-    expect(winEvents).toContain('beforeunload');
+    expect(winEvents).not.toContain('beforeunload');
     expect(winEvents).toContain('pagehide');
+    expect(winEvents).toContain('pageshow');
     expect(docEvents).toContain('visibilitychange');
   });
 
@@ -120,8 +149,8 @@ describe('setupCapture', () => {
     window.history.pushState(null, '', '/blocked');
 
     const addWin = vi.spyOn(window, 'addEventListener');
-    cleanup = setupCapture({ routes: ['/allowed'] });
-    const handler = addWin.mock.calls.find((c) => c[0] === 'beforeunload')![1] as () => void;
+    cleanup = setupCapture({ policy: { routes: ['/allowed'] } });
+    const handler = addWin.mock.calls.find((c) => c[0] === 'pagehide')![1] as () => void;
 
     handler();
     await tick();
@@ -140,6 +169,20 @@ describe('setupCapture', () => {
     expect(allowed).toBeDefined();
 
     window.history.pushState(null, '', orig || '/');
+  });
+
+  it('does not register capture listeners without an allowlist policy', () => {
+    const addWin = vi.spyOn(window, 'addEventListener');
+    const addDoc = vi.spyOn(document, 'addEventListener');
+
+    cleanup = setupCapture({ policy: null });
+
+    expect(addWin).not.toHaveBeenCalledWith('pagehide', expect.any(Function), expect.anything());
+    expect(addDoc).not.toHaveBeenCalledWith(
+      'visibilitychange',
+      expect.any(Function),
+      expect.anything(),
+    );
   });
 });
 
@@ -175,7 +218,7 @@ describe('captureSnapshot', () => {
   };
 
   it('captures first child of #root', async () => {
-    await captureSnapshot();
+    await captureSnapshot(TEST_POLICY);
     const snapshot = getSnapshot('/');
     expect(snapshot).not.toBeNull();
     expect(snapshot!.body).toBe('<div id="app">Test Content</div>');
@@ -192,7 +235,7 @@ describe('captureSnapshot', () => {
     s2.textContent = '.ignore { display:none; }';
     document.head.appendChild(s2);
 
-    await captureSnapshot();
+    await captureSnapshot(TEST_POLICY);
     const snapshot = getSnapshot('/');
     expect(snapshot).not.toBeNull();
     expect(snapshot!.styles).toBeDefined();
@@ -207,8 +250,32 @@ describe('captureSnapshot', () => {
     expect(ignored).toHaveLength(0);
   });
 
+  it('does not collect styles when policy disables them', async () => {
+    const style = document.createElement('style');
+    style.textContent = '.test { color: red; }';
+    document.head.appendChild(style);
+
+    await captureSnapshot({ routes: ['/'], includeStyles: false });
+
+    expect(getSnapshot('/')?.styles).toBeUndefined();
+  });
+
+  it('does not store snapshots larger than the configured byte limit', async () => {
+    const result = await captureSnapshot({ routes: ['/'], maxSnapshotBytes: 8 });
+
+    expect(result).toBeNull();
+    expect(getSnapshot('/')).toBeNull();
+  });
+
+  it('defaults to off when policy is missing', async () => {
+    const result = await captureSnapshot(null);
+
+    expect(result).toBeNull();
+    expect(getSnapshot('/')).toBeNull();
+  });
+
   it('handles empty styles', async () => {
-    await captureSnapshot();
+    await captureSnapshot(TEST_POLICY);
     const snapshot = getSnapshot('/');
     expect(snapshot).not.toBeNull();
     expect(snapshot!.styles).toBeUndefined();
@@ -220,7 +287,7 @@ describe('captureSnapshot', () => {
       .spyOn(document, 'querySelectorAll')
       .mockReturnValue([createFakeLink(href, true)] as unknown as NodeListOf<Element>);
 
-    await captureSnapshot();
+    await captureSnapshot(TEST_POLICY);
     const snapshot = getSnapshot('/');
     expect(snapshot).not.toBeNull();
     expect(snapshot!.styles).toContainEqual({
@@ -236,7 +303,7 @@ describe('captureSnapshot', () => {
     window.history.pushState(null, '', '/products');
     document.body.innerHTML = '<div id="root"><div>Products Page</div></div>';
 
-    await captureSnapshot();
+    await captureSnapshot(TEST_POLICY);
     const snapshot = getSnapshot('/products');
 
     expect(snapshot).not.toBeNull();
@@ -253,7 +320,7 @@ describe('captureSnapshot', () => {
     window.history.pushState(null, '', '/original');
     document.body.innerHTML = '<div id="root"><div>Custom Route</div></div>';
 
-    await captureSnapshot();
+    await captureSnapshot(TEST_POLICY);
     const snapshot = getSnapshot('/custom-key');
     const originalSnapshot = getSnapshot('/original');
 
@@ -277,7 +344,7 @@ describe('captureSnapshot', () => {
       </div>
     `;
 
-    await captureSnapshot();
+    await captureSnapshot(TEST_POLICY);
     const snapshot = getSnapshot('/');
 
     expect(snapshot).not.toBeNull();
@@ -288,7 +355,7 @@ describe('captureSnapshot', () => {
 
   it('sets timestamp on snapshot', async () => {
     const before = Date.now();
-    await captureSnapshot();
+    await captureSnapshot(TEST_POLICY);
     const snapshot = getSnapshot('/');
     const after = Date.now();
 
@@ -303,7 +370,7 @@ describe('captureSnapshot', () => {
       const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       document.body.innerHTML = '<div>No root</div>';
 
-      const result = await captureSnapshot();
+      const result = await captureSnapshot(TEST_POLICY);
 
       expect(result).toBeNull();
       expect(spy).toHaveBeenCalled();
@@ -319,7 +386,7 @@ describe('captureSnapshot', () => {
       const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
       document.body.innerHTML = '<div id="root"></div>';
 
-      const result = await captureSnapshot();
+      const result = await captureSnapshot(TEST_POLICY);
 
       expect(result).toBeNull();
       expect(spy).toHaveBeenCalled();
@@ -337,7 +404,7 @@ describe('captureSnapshot', () => {
         throw new Error('querySelectorAll failed');
       });
 
-      const result = await captureSnapshot();
+      const result = await captureSnapshot(TEST_POLICY);
 
       expect(result).toBeNull();
       expect(spy).toHaveBeenCalled();
@@ -353,7 +420,7 @@ describe('captureSnapshot', () => {
       const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const openSpy = vi.spyOn(utilsModule, 'openDB').mockRejectedValueOnce(new Error('DB Error'));
 
-      const result = await captureSnapshot();
+      const result = await captureSnapshot(TEST_POLICY);
 
       expect(result).toBeNull();
       expect(errSpy).toHaveBeenCalled();
@@ -385,7 +452,7 @@ describe('captureSnapshot', () => {
 
       vi.spyOn(utilsModule, 'openDB').mockResolvedValueOnce(dbMock as unknown as IDBDatabase);
 
-      const capturePromise = captureSnapshot();
+      const capturePromise = captureSnapshot(TEST_POLICY);
 
       const quotaError = new Error('QuotaExceededError');
       quotaError.name = 'QuotaExceededError';
@@ -410,14 +477,14 @@ describe('captureSnapshot', () => {
       vi.spyOn(console, 'error').mockImplementation(() => {});
       document.body.innerHTML = '';
 
-      await expect(captureSnapshot()).resolves.not.toThrow();
+      await expect(captureSnapshot(TEST_POLICY)).resolves.not.toThrow();
     });
 
     it('returns null on any error and continues gracefully', async () => {
       const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const openSpy = vi.spyOn(utilsModule, 'openDB').mockRejectedValue(new Error('Fatal error'));
 
-      const result = await captureSnapshot();
+      const result = await captureSnapshot(TEST_POLICY);
 
       expect(result).toBeNull();
 
@@ -438,7 +505,7 @@ describe('captureSnapshot', () => {
       </div>
     `;
 
-      await captureSnapshot();
+      await captureSnapshot(TEST_POLICY);
       const snapshot = getSnapshot('/');
 
       expect(snapshot).not.toBeNull();
@@ -460,7 +527,7 @@ describe('captureSnapshot', () => {
       </div>
     `;
 
-      await captureSnapshot();
+      await captureSnapshot(TEST_POLICY);
       const snapshot = getSnapshot('/');
 
       expect(snapshot).not.toBeNull();
@@ -480,7 +547,7 @@ describe('captureSnapshot', () => {
       </div>
     `;
 
-      await captureSnapshot();
+      await captureSnapshot(TEST_POLICY);
       const snapshot = getSnapshot('/');
 
       expect(snapshot).not.toBeNull();
@@ -502,7 +569,7 @@ describe('captureSnapshot', () => {
 
       document.body.innerHTML = '<div id="root"><div>Test</div></div>';
 
-      await captureSnapshot();
+      await captureSnapshot(TEST_POLICY);
       const snapshot = getSnapshot('/');
 
       expect(snapshot).not.toBeNull();
@@ -526,7 +593,7 @@ describe('captureSnapshot', () => {
 
       document.body.innerHTML = '<div id="root"><div>Test</div></div>';
 
-      await captureSnapshot();
+      await captureSnapshot(TEST_POLICY);
       const snapshot = getSnapshot('/');
 
       expect(snapshot).not.toBeNull();
@@ -550,7 +617,7 @@ describe('captureSnapshot', () => {
 
       document.body.innerHTML = '<div id="root"><div>Test</div></div>';
 
-      await captureSnapshot();
+      await captureSnapshot(TEST_POLICY);
       const snapshot = getSnapshot('/');
 
       expect(snapshot).not.toBeNull();

--- a/packages/prepaint/tests/hydration.test.tsx
+++ b/packages/prepaint/tests/hydration.test.tsx
@@ -4,7 +4,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { boot } from '../src/boot';
 import { createFirstTxRoot } from '../src/helpers';
 import { removeOverlay } from '../src/overlay';
-import type { Snapshot } from '../src/types';
+import { STORAGE_CONFIG, type PrepaintPolicy, type Snapshot } from '../src/types';
+
+const TEST_POLICY = {
+  routes: ['/'],
+} satisfies PrepaintPolicy;
 
 function setupRoot(inner = ''): HTMLElement {
   document.getElementById('root')?.remove();
@@ -17,7 +21,7 @@ function setupRoot(inner = ''): HTMLElement {
 
 async function saveSnapshot(snapshot: Snapshot): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const request = indexedDB.open('firsttx-prepaint', 1);
+    const request = indexedDB.open('firsttx-prepaint', STORAGE_CONFIG.DB_VERSION);
     request.onerror = () => reject(request.error ?? new Error('Failed to open snapshot database'));
     request.onupgradeneeded = () => {
       const db = request.result;
@@ -69,7 +73,7 @@ describe('visual snapshot handoff', () => {
       styles: [],
     });
 
-    await boot();
+    await boot(TEST_POLICY);
 
     expect(root.querySelector('#legacy-root')).toBeTruthy();
     expect(document.getElementById('__firsttx_prepaint__')).toBeTruthy();
@@ -109,7 +113,7 @@ describe('visual snapshot handoff', () => {
       body: '<div>Snapshot content</div>',
       styles: [],
     });
-    await boot();
+    await boot(TEST_POLICY);
 
     act(() => {
       createFirstTxRoot(root, <App />, { transition: false });
@@ -182,7 +186,7 @@ describe('visual snapshot handoff', () => {
       body: '<div>Snapshot content</div>',
       styles: [],
     });
-    await boot();
+    await boot(TEST_POLICY);
 
     act(() => {
       createFirstTxRoot(root, <div>React content</div>, { transition: true });

--- a/packages/prepaint/tests/policy.test.ts
+++ b/packages/prepaint/tests/policy.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getSnapshotPayloadBytes,
+  isRouteAllowed,
+  normalizePrepaintPolicy,
+  serializePrepaintPolicy,
+  shouldPruneSnapshot,
+  validatePrepaintPolicy,
+} from '../src/policy';
+import { STORAGE_CONFIG, type Snapshot } from '../src/types';
+
+describe('Prepaint policy', () => {
+  it('disables capture and restore when policy or routes are missing', () => {
+    expect(normalizePrepaintPolicy(undefined)).toBeNull();
+    expect(normalizePrepaintPolicy({ routes: [] })).toBeNull();
+  });
+
+  it('applies the opt-in defaults', () => {
+    expect(normalizePrepaintPolicy({ routes: ['/dashboard'] })).toEqual({
+      routes: ['/dashboard'],
+      ttlMs: STORAGE_CONFIG.MAX_SNAPSHOT_AGE,
+      maxSnapshotBytes: STORAGE_CONFIG.MAX_SNAPSHOT_BYTES,
+      includeStyles: true,
+    });
+  });
+
+  it('deduplicates exact routes without enabling prefix matches', () => {
+    const policy = normalizePrepaintPolicy({ routes: ['/cart', '/cart'] });
+
+    expect(policy?.routes).toEqual(['/cart']);
+    expect(isRouteAllowed(policy, '/cart')).toBe(true);
+    expect(isRouteAllowed(policy, '/cart/items')).toBe(false);
+  });
+
+  it('rejects invalid limits and relative routes', () => {
+    expect(() => validatePrepaintPolicy({ routes: ['dashboard'] })).toThrow('absolute pathname');
+    expect(() => validatePrepaintPolicy({ routes: ['/'], ttlMs: 0 })).toThrow('ttlMs');
+    expect(() =>
+      validatePrepaintPolicy({ routes: ['/'], maxSnapshotBytes: Number.MAX_VALUE }),
+    ).toThrow('maxSnapshotBytes');
+  });
+
+  it('measures the UTF-8 payload including stored styles', () => {
+    const withoutStyles = getSnapshotPayloadBytes({ body: '<div>한</div>' });
+    const withStyles = getSnapshotPayloadBytes({
+      body: '<div>한</div>',
+      styles: [{ type: 'inline', content: '.x{color:red}' }],
+    });
+
+    expect(withoutStyles).toBeGreaterThan('<div>한</div>'.length);
+    expect(withStyles).toBeGreaterThan(withoutStyles);
+  });
+
+  it('prunes disallowed, expired, oversized, and style-bearing records', () => {
+    const snapshot: Snapshot = {
+      route: '/allowed',
+      body: '<div>Saved</div>',
+      timestamp: 1000,
+      styles: [{ type: 'inline', content: '.x{}' }],
+    };
+
+    const basePolicy = validatePrepaintPolicy({
+      routes: ['/allowed'],
+      ttlMs: 1000,
+      maxSnapshotBytes: 10_000,
+      includeStyles: true,
+    });
+
+    expect(shouldPruneSnapshot(snapshot, basePolicy, 1500)).toBe(false);
+    expect(shouldPruneSnapshot({ ...snapshot, route: '/blocked' }, basePolicy, 1500)).toBe(true);
+    expect(shouldPruneSnapshot(snapshot, basePolicy, 2501)).toBe(true);
+    expect(
+      shouldPruneSnapshot(
+        snapshot,
+        validatePrepaintPolicy({
+          routes: ['/allowed'],
+          maxSnapshotBytes: 1,
+        }),
+        1500,
+      ),
+    ).toBe(true);
+    expect(
+      shouldPruneSnapshot(
+        snapshot,
+        validatePrepaintPolicy({
+          routes: ['/allowed'],
+          includeStyles: false,
+        }),
+        1500,
+      ),
+    ).toBe(true);
+  });
+
+  it('escapes policy values before embedding them in a script', () => {
+    const serialized = serializePrepaintPolicy({ routes: ['/</script>\u2028'] });
+
+    expect(serialized).not.toContain('</script>');
+    expect(serialized).not.toContain('\u2028');
+    expect(serialized).toContain('\\u003c');
+    expect(serialized).toContain('\\u2028');
+  });
+});

--- a/packages/prepaint/tests/reinit-risks.test.tsx
+++ b/packages/prepaint/tests/reinit-risks.test.tsx
@@ -25,11 +25,21 @@ describe('Re-initialization behavior', () => {
     window.history.pushState(null, '', '/');
     vi.restoreAllMocks();
     vi.resetModules();
+    (
+      globalThis as typeof globalThis & {
+        __FIRSTTX_PREPAINT_POLICY__?: unknown;
+      }
+    ).__FIRSTTX_PREPAINT_POLICY__ = { routes: ['/', '/allowed', '/blocked'] };
   });
 
   afterEach(() => {
     cleanupRoots();
     vi.restoreAllMocks();
+    delete (
+      globalThis as typeof globalThis & {
+        __FIRSTTX_PREPAINT_POLICY__?: unknown;
+      }
+    ).__FIRSTTX_PREPAINT_POLICY__;
   });
 
   it('uses the latest onCapture callback after createFirstTxRoot re-init', async () => {
@@ -51,7 +61,7 @@ describe('Re-initialization behavior', () => {
     });
 
     act(() => {
-      window.dispatchEvent(new Event('beforeunload'));
+      window.dispatchEvent(new Event('pagehide'));
     });
 
     await waitFor(() => {
@@ -60,7 +70,7 @@ describe('Re-initialization behavior', () => {
     });
   });
 
-  it('does not install root-guard listeners across repeated createFirstTxRoot calls', async () => {
+  it('does not duplicate capture lifecycle listeners across repeated roots', async () => {
     const { createFirstTxRoot } = await import('../src/helpers');
     const addSpy = vi.spyOn(window, 'addEventListener');
 
@@ -85,7 +95,7 @@ describe('Re-initialization behavior', () => {
     const addedPageshow = addSpy.mock.calls.filter((call) => call[0] === 'pageshow').length;
 
     expect(addedPopstate).toBe(0);
-    expect(addedPageshow).toBe(0);
+    expect(addedPageshow).toBe(1);
   });
 
   it('applies second setupCapture options on repeated setup', async () => {
@@ -97,12 +107,15 @@ describe('Re-initialization behavior', () => {
     const firstOnCapture = vi.fn();
     const secondOnCapture = vi.fn();
 
-    const cleanup = setupCapture({ routes: ['/allowed'], onCapture: firstOnCapture });
-    setupCapture({ routes: ['/blocked'], onCapture: secondOnCapture });
+    const cleanup = setupCapture({
+      policy: { routes: ['/allowed'] },
+      onCapture: firstOnCapture,
+    });
+    setupCapture({ policy: { routes: ['/blocked'] }, onCapture: secondOnCapture });
 
     act(() => {
       window.history.pushState(null, '', '/blocked');
-      window.dispatchEvent(new Event('beforeunload'));
+      window.dispatchEvent(new Event('pagehide'));
     });
 
     await waitFor(() => {
@@ -122,7 +135,7 @@ describe('Re-initialization behavior', () => {
       <div id="app-b">App B</div>
     `;
 
-    const snapshot = await captureSnapshot();
+    const snapshot = await captureSnapshot({ routes: ['/'] });
 
     expect(snapshot).not.toBeNull();
     expect(snapshot?.body).toContain('app-a');

--- a/packages/prepaint/tests/sanitize.test.ts
+++ b/packages/prepaint/tests/sanitize.test.ts
@@ -146,6 +146,20 @@ describe('sanitize', () => {
         expect(result).not.toContain('JAVASCRIPT:');
       });
 
+      it('removes javascript: href with embedded control characters', () => {
+        const html = '<a href="java&#10;script:alert(1)">Click</a>';
+        const result = sanitizeSnapshotHTMLSync(html);
+
+        expect(result).not.toContain('href=');
+      });
+
+      it('removes data:text/html URLs with embedded whitespace', () => {
+        const html = '<a href="data: text/html,<p>unsafe</p>">Click</a>';
+        const result = sanitizeSnapshotHTMLSync(html);
+
+        expect(result).not.toContain('href=');
+      });
+
       it('removes data:text/html URLs', () => {
         const html = '<a href="data:text/html,<script>alert(1)</script>">Click</a>';
         const result = sanitizeSnapshotHTMLSync(html);

--- a/packages/prepaint/tests/utils.test.ts
+++ b/packages/prepaint/tests/utils.test.ts
@@ -50,4 +50,42 @@ describe('openDB', () => {
 
     expect(db.version).toBe(STORAGE_CONFIG.DB_VERSION);
   });
+
+  it('should purge version 1 snapshots during the version 2 upgrade', async () => {
+    const legacyRequest = indexedDB.open(STORAGE_CONFIG.DB_NAME, 1);
+    const legacyDb = await new Promise<IDBDatabase>((resolve, reject) => {
+      legacyRequest.onupgradeneeded = () => {
+        legacyRequest.result.createObjectStore(STORAGE_CONFIG.STORE_SNAPSHOTS, {
+          keyPath: 'route',
+        });
+      };
+      legacyRequest.onsuccess = () => resolve(legacyRequest.result);
+      legacyRequest.onerror = () =>
+        reject(legacyRequest.error ?? new Error('Failed to open legacy database'));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = legacyDb.transaction(STORAGE_CONFIG.STORE_SNAPSHOTS, 'readwrite');
+      const request = tx.objectStore(STORAGE_CONFIG.STORE_SNAPSHOTS).put({
+        route: '/',
+        body: '<div>Legacy</div>',
+        timestamp: Date.now(),
+      });
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error ?? new Error('Failed to store legacy snapshot'));
+    });
+    legacyDb.close();
+
+    db = await openDB();
+
+    const stored = await new Promise<unknown>((resolve, reject) => {
+      const tx = db!.transaction(STORAGE_CONFIG.STORE_SNAPSHOTS, 'readonly');
+      const request = tx.objectStore(STORAGE_CONFIG.STORE_SNAPSHOTS).get('/');
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () =>
+        reject(request.error ?? new Error('Failed to read migrated snapshot'));
+    });
+
+    expect(stored).toBeUndefined();
+  });
 });

--- a/packages/prepaint/tests/vite-plugin.test.ts
+++ b/packages/prepaint/tests/vite-plugin.test.ts
@@ -56,6 +56,7 @@ describe('firstTx Vite Plugin', () => {
         nonce: 'test-nonce',
         overlay: true,
         overlayRoutes: ['/cart', '/checkout'],
+        policy: { routes: ['/cart', '/checkout'] },
         devFlagOverride: true,
       };
       const plugin = firstTx(options);
@@ -83,7 +84,7 @@ describe('firstTx Vite Plugin', () => {
       const plugin = firstTx();
       const configResolved = plugin.configResolved as (config: ResolvedConfig) => void;
 
-      configResolved({ mode: 'production' } as ResolvedConfig);
+      configResolved({ mode: 'production', command: 'build' } as ResolvedConfig);
 
       const buildStart = plugin.buildStart as () => Promise<void>;
       await buildStart();
@@ -97,7 +98,7 @@ describe('firstTx Vite Plugin', () => {
       const plugin = firstTx({ devFlagOverride: true });
       const configResolved = plugin.configResolved as (config: ResolvedConfig) => void;
 
-      configResolved({ mode: 'production' } as ResolvedConfig);
+      configResolved({ mode: 'production', command: 'build' } as ResolvedConfig);
 
       const buildStart = plugin.buildStart as () => Promise<void>;
       await buildStart();
@@ -206,29 +207,29 @@ describe('firstTx Vite Plugin', () => {
       return transformIndexHtml.handler;
     }
 
-    it('injects inline script to head-prepend by default', async () => {
-      const handler = await getTransformHandler();
+    it('injects an inline script when explicitly enabled', async () => {
+      const handler = await getTransformHandler({ inline: true });
       const html = '<html><head><title>Test</title></head><body></body></html>';
 
       const result = handler(html);
 
       expect(result).toContain('<head>');
-      expect(result).toContain('__firsttx_boot__.boot()');
+      expect(result).toContain('__firsttx_boot__.boot(globalThis.__FIRSTTX_PREPAINT_POLICY__)');
       expect(result).toMatch(/<head>\s*<script>/);
     });
 
     it('injects script to head position', async () => {
-      const handler = await getTransformHandler({ injectTo: 'head' });
+      const handler = await getTransformHandler({ injectTo: 'head', inline: true });
       const html = '<html><head><title>Test</title></head><body></body></html>';
 
       const result = handler(html);
 
       expect(result).toMatch(/<\/head>/);
-      expect(result).toContain('__firsttx_boot__.boot()');
+      expect(result).toContain('__firsttx_boot__.boot(globalThis.__FIRSTTX_PREPAINT_POLICY__)');
     });
 
     it('injects script to body-prepend position', async () => {
-      const handler = await getTransformHandler({ injectTo: 'body-prepend' });
+      const handler = await getTransformHandler({ injectTo: 'body-prepend', inline: true });
       const html = '<html><head></head><body><div>Content</div></body></html>';
 
       const result = handler(html);
@@ -237,7 +238,7 @@ describe('firstTx Vite Plugin', () => {
     });
 
     it('injects script to body position', async () => {
-      const handler = await getTransformHandler({ injectTo: 'body' });
+      const handler = await getTransformHandler({ injectTo: 'body', inline: true });
       const html = '<html><head></head><body><div>Content</div></body></html>';
 
       const result = handler(html);
@@ -281,6 +282,26 @@ describe('firstTx Vite Plugin', () => {
       expect(() => handler(html)).toThrow('[FirstTx] Invalid nonce value');
     });
 
+    it('rejects invalid snapshot policy values', () => {
+      expect(() => firstTx({ policy: { routes: ['dashboard'] } })).toThrow(
+        '[FirstTx] Invalid prepaint policy',
+      );
+      expect(() => firstTx({ policy: { routes: ['/'], ttlMs: 0 } })).toThrow(
+        '[FirstTx] Invalid prepaint policy',
+      );
+    });
+
+    it('escapes policy values in inline output', async () => {
+      const handler = await getTransformHandler({
+        inline: true,
+        policy: { routes: ['/</script>\u2028'] },
+      });
+      const result = handler('<html><head></head><body></body></html>');
+
+      expect(result).not.toContain('</script>\u2028');
+      expect(result).toContain('\\u003c/script\\u003e\\u2028');
+    });
+
     it('keeps deprecated overlay options as no-ops', async () => {
       const handler = await getTransformHandler({
         overlay: true,
@@ -295,7 +316,7 @@ describe('firstTx Vite Plugin', () => {
     });
 
     it('wraps boot script in try-catch', async () => {
-      const handler = await getTransformHandler();
+      const handler = await getTransformHandler({ inline: true });
       const html = '<html><head></head><body></body></html>';
 
       const result = handler(html);
@@ -307,8 +328,8 @@ describe('firstTx Vite Plugin', () => {
   });
 
   describe('non-inline mode', () => {
-    it('uses external script when inline is false', async () => {
-      const plugin = firstTx({ inline: false });
+    it('uses an external script by default', async () => {
+      const plugin = firstTx();
       const configResolved = plugin.configResolved as (config: ResolvedConfig) => void;
       configResolved({ mode: 'production' } as ResolvedConfig);
 
@@ -321,53 +342,48 @@ describe('firstTx Vite Plugin', () => {
       };
       const result = transformIndexHtml.handler('<html><head></head><body></body></html>');
 
+      expect(result).toContain('<script vite-ignore');
       expect(result).toContain('src="/firsttx-boot.js"');
       expect(result).not.toContain('__firsttx_boot__.boot()');
     });
 
-    it('resolves virtual module id', () => {
-      const plugin = firstTx({ inline: false });
-      const resolveId = plugin.resolveId as (id: string) => string | undefined;
+    it('emits a self-starting boot asset', async () => {
+      const plugin = firstTx({ policy: { routes: ['/cart'] } });
+      const configResolved = plugin.configResolved as (config: ResolvedConfig) => void;
+      configResolved({ mode: 'production', command: 'build' } as ResolvedConfig);
 
-      expect(resolveId('/firsttx-boot.js')).toBe('/firsttx-boot.js');
-      expect(resolveId('/other.js')).toBeUndefined();
+      const emitFile = vi.fn((file: unknown) => String(file));
+      const buildStart = plugin.buildStart as unknown as (this: {
+        emitFile: typeof emitFile;
+      }) => Promise<void>;
+      await buildStart.call({ emitFile });
+
+      expect(emitFile).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'asset', fileName: 'firsttx-boot.js' }),
+      );
+      const emitted = emitFile.mock.calls[0]?.[0];
+      if (!emitted || typeof emitted !== 'object' || !('source' in emitted)) {
+        throw new Error('Expected an emitted asset source');
+      }
+      const source = String(emitted.source);
+      expect(source).toContain('console.log("boot script");');
+      expect(source).toContain('globalThis.__FIRSTTX_PREPAINT_POLICY__=');
+      expect(source).toContain('"routes":["/cart"]');
+      expect(source).toContain('__firsttx_boot__.boot(globalThis.__FIRSTTX_PREPAINT_POLICY__)');
     });
 
-    it('does not resolve virtual module when inline is true', () => {
+    it('does not emit an external asset in inline mode', async () => {
       const plugin = firstTx({ inline: true });
-      const resolveId = plugin.resolveId as (id: string) => string | undefined;
-
-      expect(resolveId('/firsttx-boot.js')).toBeUndefined();
-    });
-
-    it('loads virtual module with boot script code', async () => {
-      const plugin = firstTx({ inline: false });
       const configResolved = plugin.configResolved as (config: ResolvedConfig) => void;
-      configResolved({ mode: 'production' } as ResolvedConfig);
+      configResolved({ mode: 'production', command: 'build' } as ResolvedConfig);
 
-      const buildStart = plugin.buildStart as () => Promise<void>;
-      await buildStart();
+      const emitFile = vi.fn();
+      const buildStart = plugin.buildStart as unknown as (this: {
+        emitFile: typeof emitFile;
+      }) => Promise<void>;
+      await buildStart.call({ emitFile });
 
-      const load = plugin.load as (id: string) => { code: string; map: null } | undefined;
-      const result = load('/firsttx-boot.js');
-
-      expect(result).toEqual({
-        code: 'console.log("boot script");',
-        map: null,
-      });
-    });
-
-    it('does not load non-virtual modules', async () => {
-      const plugin = firstTx({ inline: false });
-      const configResolved = plugin.configResolved as (config: ResolvedConfig) => void;
-      configResolved({ mode: 'production' } as ResolvedConfig);
-
-      const buildStart = plugin.buildStart as () => Promise<void>;
-      await buildStart();
-
-      const load = plugin.load as (id: string) => { code: string; map: null } | undefined;
-
-      expect(load('/other.js')).toBeUndefined();
+      expect(emitFile).not.toHaveBeenCalled();
     });
   });
 });
@@ -386,7 +402,7 @@ describe('injectScript helper', () => {
       mangleCache: undefined,
     });
 
-    const plugin = firstTx({ injectTo: position });
+    const plugin = firstTx({ injectTo: position, inline: true });
     const configResolved = plugin.configResolved as (config: ResolvedConfig) => void;
     configResolved({ mode: 'production' } as ResolvedConfig);
 
@@ -425,7 +441,7 @@ describe('injectScript helper', () => {
       mangleCache: undefined,
     });
 
-    const plugin = firstTx({ injectTo: 'unknown' as 'head' });
+    const plugin = firstTx({ injectTo: 'unknown' as 'head', inline: true });
     const configResolved = plugin.configResolved as (config: ResolvedConfig) => void;
     configResolved({ mode: 'production' } as ResolvedConfig);
 


### PR DESCRIPTION
## Summary

Implement Prepaint's save and restore security policies

## Changes

- Added the `firstTx({ policy: { routes, ttlMs, maxSnapshotBytes, includeStyles } })` API
- Disabled capture and restore by default when the policy is missing or routes are empty
- Applied the exact pathname allowlist uniformly to capture, restore, and storage pruning
- Applied a policy with a default TTL of 7 days, a maximum snapshot size of 1 MiB, and CSS included
- Upgraded the IndexedDB schema to v2 and discarded existing v1 snapshots during migration
- Removed snapshots that are disallowed, expired, oversized, or have CSS policy mismatches at boot time
- Applied idle capture and `visibilitychange`/`pagehide` final saves
- Removed the `beforeunload` listener
- Changed the default Vite boot method to the self-starting external asset `/firsttx-boot.js`
- Maintained `inline: true` as the path for using explicit CSP hashes
- Enhanced the fallback sanitizer’s blocking of obfuscated risky URLs
- Updated English and Korean documentation to reflect CSS threat boundaries and migration details
- Added a changeset

## Migration

Snapshot capture and restore will be disabled for existing calls to `firstTx()`.

```ts
firstTx({
  policy: {
    routes: ['/dashboard', '/cart'],
  },
});