### PR TITLE
ci: create GitHub releases after package publish

### DIFF
--- a/.github/scripts/create-github-releases.js
+++ b/.github/scripts/create-github-releases.js
@@ -1,0 +1,364 @@
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PACKAGE_NAME_PATTERN = /^@firsttx\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const VERSION_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const PACKAGE_MANIFEST_PATTERN = /^packages\/[a-z0-9-]+\/package\.json$/;
+
+function parsePackageManifests(value) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 20_000) {
+    throw new Error('PACKAGE_MANIFESTS must be a non-empty JSON string');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error('PACKAGE_MANIFESTS must contain valid JSON', { cause: error });
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0 || parsed.length > 50) {
+    throw new Error('PACKAGE_MANIFESTS must contain between 1 and 50 paths');
+  }
+
+  const paths = new Set();
+
+  return parsed.map((manifestPath) => {
+    if (typeof manifestPath !== 'string' || !PACKAGE_MANIFEST_PATTERN.test(manifestPath)) {
+      throw new Error('PACKAGE_MANIFESTS contains an invalid path');
+    }
+
+    if (paths.has(manifestPath)) {
+      throw new Error(`PACKAGE_MANIFESTS contains duplicate path ${manifestPath}`);
+    }
+
+    paths.add(manifestPath);
+    return manifestPath;
+  });
+}
+
+function parsePublishedPackages(value) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 20_000) {
+    throw new Error('PUBLISHED_PACKAGES must be a non-empty JSON string');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error('PUBLISHED_PACKAGES must contain valid JSON', { cause: error });
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0 || parsed.length > 50) {
+    throw new Error('PUBLISHED_PACKAGES must contain between 1 and 50 packages');
+  }
+
+  const names = new Set();
+
+  return parsed.map((entry) => {
+    if (
+      entry === null ||
+      typeof entry !== 'object' ||
+      typeof entry.name !== 'string' ||
+      typeof entry.version !== 'string' ||
+      !PACKAGE_NAME_PATTERN.test(entry.name) ||
+      !VERSION_PATTERN.test(entry.version)
+    ) {
+      throw new Error('PUBLISHED_PACKAGES contains an invalid package');
+    }
+
+    if (names.has(entry.name)) {
+      throw new Error(`PUBLISHED_PACKAGES contains duplicate package ${entry.name}`);
+    }
+
+    names.add(entry.name);
+    return { name: entry.name, version: entry.version };
+  });
+}
+
+function extractReleaseNotes(changelog, version) {
+  const lines = changelog.split(/\r?\n/);
+  const heading = `## ${version}`;
+  const start = lines.findIndex((line) => line.trim() === heading);
+
+  if (start === -1) {
+    throw new Error(`Could not find changelog entry for version ${version}`);
+  }
+
+  const nextHeading = lines.findIndex((line, index) => index > start && /^##\s+\S/.test(line));
+  const notes = lines
+    .slice(start + 1, nextHeading === -1 ? undefined : nextHeading)
+    .join('\n')
+    .trim();
+
+  if (notes.length === 0) {
+    throw new Error(`Changelog entry for version ${version} is empty`);
+  }
+
+  if (notes.length > 60_000) {
+    throw new Error(`Changelog entry for version ${version} exceeds 60000 characters`);
+  }
+
+  return `${notes}\n`;
+}
+
+function publishedPackagesFromManifests(rootDir, manifestPaths) {
+  const packages = manifestPaths.map((manifestPath) => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(rootDir, manifestPath), 'utf8'));
+    return { name: manifest.name, version: manifest.version };
+  });
+
+  return parsePublishedPackages(JSON.stringify(packages));
+}
+
+function createReleasePlan(rootDir, publishedPackages) {
+  const packageRoot = path.join(rootDir, 'packages');
+  const manifests = new Map();
+
+  for (const entry of fs.readdirSync(packageRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const packageDir = path.join(packageRoot, entry.name);
+    const manifestPath = path.join(packageDir, 'package.json');
+
+    if (!fs.existsSync(manifestPath)) {
+      continue;
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+    if (typeof manifest.name === 'string') {
+      manifests.set(manifest.name, { manifest, packageDir });
+    }
+  }
+
+  return publishedPackages.map(({ name, version }) => {
+    const found = manifests.get(name);
+
+    if (!found || found.manifest.private === true || found.manifest.version !== version) {
+      throw new Error(`Published package ${name}@${version} does not match the verified revision`);
+    }
+
+    const changelogPath = path.join(found.packageDir, 'CHANGELOG.md');
+
+    if (!fs.existsSync(changelogPath)) {
+      throw new Error(`Missing changelog for ${name}@${version}`);
+    }
+
+    return {
+      name,
+      version,
+      tag: `${name}@${version}`,
+      prerelease: version.includes('-'),
+      notes: extractReleaseNotes(fs.readFileSync(changelogPath, 'utf8'), version),
+    };
+  });
+}
+
+function commandError(command, result) {
+  const details = `${result.stderr || result.stdout || ''}`.trim();
+  const error = new Error(`${command} failed${details ? `: ${details}` : ''}`);
+  const statusMatch = details.match(/HTTP (\d{3})/);
+
+  if (statusMatch) {
+    error.httpStatus = Number(statusMatch[1]);
+  }
+
+  return error;
+}
+
+function runCommand(command, args, input) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    input,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw commandError(`${command} ${args.join(' ')}`, result);
+  }
+
+  return result.stdout.trim();
+}
+
+function createCliApi(repository) {
+  function request(method, endpoint, body) {
+    const args = [
+      'api',
+      '--method',
+      method,
+      '-H',
+      'Accept: application/vnd.github+json',
+      '-H',
+      'X-GitHub-Api-Version: 2022-11-28',
+      endpoint,
+    ];
+
+    if (body !== undefined) {
+      args.push('--input', '-');
+    }
+
+    const output = runCommand('gh', args, body === undefined ? undefined : JSON.stringify(body));
+    return output === '' ? null : JSON.parse(output);
+  }
+
+  function optionalRequest(endpoint) {
+    try {
+      return request('GET', endpoint);
+    } catch (error) {
+      if (error.httpStatus === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  function resolveTagTarget(tag) {
+    const ref = optionalRequest(`repos/${repository}/git/ref/${encodeURIComponent(`tags/${tag}`)}`);
+
+    if (ref === null) {
+      return null;
+    }
+
+    let object = ref.object;
+
+    for (let depth = 0; depth < 5; depth += 1) {
+      if (object.type === 'commit') {
+        return object.sha;
+      }
+
+      if (object.type !== 'tag') {
+        throw new Error(`Tag ${tag} points to unsupported object type ${object.type}`);
+      }
+
+      object = request('GET', `repos/${repository}/git/tags/${object.sha}`).object;
+    }
+
+    throw new Error(`Tag ${tag} contains too many nested tag objects`);
+  }
+
+  return {
+    getPublishedVersion(name, version) {
+      const output = runCommand('npm', ['view', `${name}@${version}`, 'version', '--json']);
+      return JSON.parse(output);
+    },
+    getRelease(tag) {
+      return optionalRequest(`repos/${repository}/releases/tags/${encodeURIComponent(tag)}`);
+    },
+    getTagTarget: resolveTagTarget,
+    createRelease(release, releaseSha) {
+      return request('POST', `repos/${repository}/releases`, {
+        tag_name: release.tag,
+        target_commitish: releaseSha,
+        name: release.tag,
+        body: release.notes,
+        draft: false,
+        prerelease: release.prerelease,
+        generate_release_notes: false,
+      });
+    },
+  };
+}
+
+function validateExistingRelease(release, planned) {
+  if (
+    release.tag_name !== planned.tag ||
+    release.draft !== false ||
+    release.prerelease !== planned.prerelease
+  ) {
+    throw new Error(`Existing release ${planned.tag} does not match the release plan`);
+  }
+}
+
+function createGithubReleases({ plan, releaseSha, api, dryRun = false, log = console.log }) {
+  if (!SHA_PATTERN.test(releaseSha)) {
+    throw new Error('RELEASE_SHA must be a full lowercase commit SHA');
+  }
+
+  for (const planned of plan) {
+    const publishedVersion = api.getPublishedVersion(planned.name, planned.version);
+
+    if (publishedVersion !== planned.version) {
+      throw new Error(`npm does not contain ${planned.name}@${planned.version}`);
+    }
+
+    const existingRelease = api.getRelease(planned.tag);
+    const existingTarget = api.getTagTarget(planned.tag);
+
+    if (existingTarget !== null && existingTarget !== releaseSha) {
+      throw new Error(
+        `Existing tag ${planned.tag} points to ${existingTarget}, expected ${releaseSha}`,
+      );
+    }
+
+    if (existingRelease !== null) {
+      if (existingTarget === null) {
+        throw new Error(`Existing release ${planned.tag} has no matching tag`);
+      }
+
+      validateExistingRelease(existingRelease, planned);
+      log(`Release ${planned.tag} already exists at the verified revision`);
+      continue;
+    }
+
+    if (dryRun) {
+      log(`Would create release ${planned.tag} at ${releaseSha}`);
+      continue;
+    }
+
+    api.createRelease(planned, releaseSha);
+
+    const createdRelease = api.getRelease(planned.tag);
+    const createdTarget = api.getTagTarget(planned.tag);
+
+    if (createdRelease === null || createdTarget !== releaseSha) {
+      throw new Error(`Failed to verify created release ${planned.tag}`);
+    }
+
+    validateExistingRelease(createdRelease, planned);
+    log(`Created release ${planned.tag}`);
+  }
+}
+
+function main() {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const releaseSha = process.env.RELEASE_SHA;
+
+  if (typeof repository !== 'string' || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error('GITHUB_REPOSITORY is invalid');
+  }
+
+  const manifestPaths = parsePackageManifests(process.env.PACKAGE_MANIFESTS);
+  const publishedPackages = publishedPackagesFromManifests(process.cwd(), manifestPaths);
+  const plan = createReleasePlan(process.cwd(), publishedPackages);
+  const api = createCliApi(repository);
+
+  createGithubReleases({
+    plan,
+    releaseSha,
+    api,
+    dryRun: process.env.RELEASE_DRY_RUN === 'true',
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  createGithubReleases,
+  createReleasePlan,
+  extractReleaseNotes,
+  parsePackageManifests,
+  parsePublishedPackages,
+  publishedPackagesFromManifests,
+};

--- a/.github/scripts/create-github-releases.test.js
+++ b/.github/scripts/create-github-releases.test.js
@@ -1,0 +1,224 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  createGithubReleases,
+  createReleasePlan,
+  extractReleaseNotes,
+  parsePackageManifests,
+  parsePublishedPackages,
+  publishedPackagesFromManifests,
+} = require('./create-github-releases');
+
+const RELEASE_SHA = '0123456789abcdef0123456789abcdef01234567';
+
+function createFixture() {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'firsttx-release-'));
+  const packageDir = path.join(rootDir, 'packages', 'prepaint');
+
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageDir, 'package.json'),
+    JSON.stringify({ name: '@firsttx/prepaint', version: '1.2.3' }),
+  );
+  fs.writeFileSync(
+    path.join(packageDir, 'CHANGELOG.md'),
+    '# @firsttx/prepaint\n\n## 1.2.3\n\n- Safe release\n\n## 1.2.2\n\n- Previous\n',
+  );
+
+  return rootDir;
+}
+
+function createApi({ publishedVersion = '1.2.3', target = null, release = null } = {}) {
+  let currentTarget = target;
+  let currentRelease = release;
+  const created = [];
+
+  return {
+    created,
+    getPublishedVersion() {
+      return publishedVersion;
+    },
+    getRelease() {
+      return currentRelease;
+    },
+    getTagTarget() {
+      return currentTarget;
+    },
+    createRelease(planned, releaseSha) {
+      created.push({ planned, releaseSha });
+      currentTarget = releaseSha;
+      currentRelease = {
+        tag_name: planned.tag,
+        draft: false,
+        prerelease: planned.prerelease,
+      };
+    },
+  };
+}
+
+test('parses and validates published packages', () => {
+  assert.deepEqual(parsePublishedPackages('[{"name":"@firsttx/prepaint","version":"1.2.3"}]'), [
+    { name: '@firsttx/prepaint', version: '1.2.3' },
+  ]);
+  assert.throws(
+    () => parsePublishedPackages('[{"name":"other","version":"1.2.3"}]'),
+    /invalid package/,
+  );
+  assert.throws(
+    () =>
+      parsePublishedPackages(
+        '[{"name":"@firsttx/prepaint","version":"1.2.3"},{"name":"@firsttx/prepaint","version":"1.2.4"}]',
+      ),
+    /duplicate package/,
+  );
+});
+
+test('parses and validates package manifest paths', () => {
+  assert.deepEqual(parsePackageManifests('["packages/prepaint/package.json"]'), [
+    'packages/prepaint/package.json',
+  ]);
+  assert.throws(() => parsePackageManifests('["apps/docs/package.json"]'), /invalid path/);
+  assert.throws(
+    () =>
+      parsePackageManifests('["packages/prepaint/package.json","packages/prepaint/package.json"]'),
+    /duplicate path/,
+  );
+});
+
+test('extracts only the requested changelog section', () => {
+  const notes = extractReleaseNotes(
+    '# Package\n\n## 1.2.3\n\n- Current\n\n## Unreleased\n\n- Future\n',
+    '1.2.3',
+  );
+
+  assert.equal(notes, '- Current\n');
+});
+
+test('builds a release plan from the verified package manifests', (context) => {
+  const rootDir = createFixture();
+  context.after(() => fs.rmSync(rootDir, { recursive: true, force: true }));
+
+  const publishedPackages = publishedPackagesFromManifests(rootDir, [
+    'packages/prepaint/package.json',
+  ]);
+
+  assert.deepEqual(createReleasePlan(rootDir, publishedPackages), [
+    {
+      name: '@firsttx/prepaint',
+      version: '1.2.3',
+      tag: '@firsttx/prepaint@1.2.3',
+      prerelease: false,
+      notes: '- Safe release\n',
+    },
+  ]);
+  assert.throws(
+    () => createReleasePlan(rootDir, [{ name: '@firsttx/prepaint', version: '1.2.4' }]),
+    /does not match the verified revision/,
+  );
+});
+
+test('creates and verifies a missing release', () => {
+  const api = createApi();
+  const plan = [
+    {
+      name: '@firsttx/prepaint',
+      version: '1.2.3',
+      tag: '@firsttx/prepaint@1.2.3',
+      prerelease: false,
+      notes: '- Safe release\n',
+    },
+  ];
+
+  createGithubReleases({ plan, releaseSha: RELEASE_SHA, api, log() {} });
+
+  assert.equal(api.created.length, 1);
+  assert.equal(api.created[0].releaseSha, RELEASE_SHA);
+});
+
+test('dry-run validates a missing release without creating it', () => {
+  const api = createApi();
+  const messages = [];
+  const plan = [
+    {
+      name: '@firsttx/prepaint',
+      version: '1.2.3',
+      tag: '@firsttx/prepaint@1.2.3',
+      prerelease: false,
+      notes: '- Safe release\n',
+    },
+  ];
+
+  createGithubReleases({
+    plan,
+    releaseSha: RELEASE_SHA,
+    api,
+    dryRun: true,
+    log(message) {
+      messages.push(message);
+    },
+  });
+
+  assert.equal(api.created.length, 0);
+  assert.deepEqual(messages, [`Would create release @firsttx/prepaint@1.2.3 at ${RELEASE_SHA}`]);
+});
+
+test('skips an existing release at the verified revision', () => {
+  const api = createApi({
+    target: RELEASE_SHA,
+    release: {
+      tag_name: '@firsttx/prepaint@1.2.3',
+      draft: false,
+      prerelease: false,
+    },
+  });
+  const plan = [
+    {
+      name: '@firsttx/prepaint',
+      version: '1.2.3',
+      tag: '@firsttx/prepaint@1.2.3',
+      prerelease: false,
+      notes: '- Safe release\n',
+    },
+  ];
+
+  createGithubReleases({ plan, releaseSha: RELEASE_SHA, api, log() {} });
+
+  assert.equal(api.created.length, 0);
+});
+
+test('rejects npm mismatches and conflicting tags', () => {
+  const plan = [
+    {
+      name: '@firsttx/prepaint',
+      version: '1.2.3',
+      tag: '@firsttx/prepaint@1.2.3',
+      prerelease: false,
+      notes: '- Safe release\n',
+    },
+  ];
+
+  assert.throws(
+    () =>
+      createGithubReleases({
+        plan,
+        releaseSha: RELEASE_SHA,
+        api: createApi({ publishedVersion: '1.2.2' }),
+        log() {},
+      }),
+    /npm does not contain/,
+  );
+  assert.throws(
+    () =>
+      createGithubReleases({
+        plan,
+        releaseSha: RELEASE_SHA,
+        api: createApi({ target: 'abcdef0123456789abcdef0123456789abcdef01' }),
+        log() {},
+      }),
+    /points to/,
+  );
+});

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       pull-requests: read
     outputs:
       publish: ${{ steps.route.outputs.publish }}
+      package-manifests: ${{ steps.route.outputs.package-manifests }}
     steps:
       - name: Identify the merged pull request
         id: route
@@ -30,15 +31,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          head_ref="$(gh api \
+          pull_request="$(gh api \
             --header 'Accept: application/vnd.github+json' \
             "/repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
-            --jq '[.[] | select(.merged_at != null)] | sort_by(.merged_at) | reverse | .[0].head.ref // ""')"
+            --jq '[.[] | select(.merged_at != null)] | sort_by(.merged_at) | reverse | .[0] // {}')"
+          head_ref="$(jq -r '.head.ref // ""' <<< "$pull_request")"
 
           if [[ "$head_ref" == "changeset-release/main" ]]; then
+            pull_request_number="$(jq -r '.number' <<< "$pull_request")"
+            package_manifests="$(gh api --paginate --slurp \
+              --header 'Accept: application/vnd.github+json' \
+              "/repos/${GITHUB_REPOSITORY}/pulls/${pull_request_number}/files?per_page=100" \
+              | jq -c '[.[][] | select(.status != "removed") | .filename | select(test("^packages/[a-z0-9-]+/package\\.json$"))]')"
+
+            if ! jq -e 'length > 0' <<< "$package_manifests" > /dev/null; then
+              echo 'No package manifests changed in the release pull request' >&2
+              exit 1
+            fi
+
             echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "package-manifests=$package_manifests" >> "$GITHUB_OUTPUT"
           else
             echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo 'package-manifests=[]' >> "$GITHUB_OUTPUT"
           fi
 
   version-pr:
@@ -106,3 +121,30 @@ jobs:
         run: pnpm run release:publish
         env:
           NPM_CONFIG_PROVENANCE: 'true'
+
+  github-release:
+    name: Create GitHub releases
+    needs: [route, publish]
+    if: needs.publish.result == 'success' && needs.route.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout verified revision
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Create package tags and releases
+        run: node .github/scripts/create-github-releases.js
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_MANIFESTS: ${{ needs.route.outputs.package-manifests }}
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ docs/temp.*
 .env*.local
 .claude/**/*.json
 artifacts/
+
+.docs/git-convention.md

--- a/package.json
+++ b/package.json
@@ -36,11 +36,12 @@
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "typecheck": "turbo run typecheck",
-    "verify": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test:coverage && pnpm --filter @firsttx/docs test:run",
+    "verify": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test:coverage && pnpm --filter @firsttx/docs test:run && pnpm run test:release",
     "format": "prettier -w \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
     "release:version": "changeset version && pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile",
     "release:publish": "turbo run build --filter='./packages/*' && changeset publish",
+    "test:release": "node --test .github/scripts/*.test.js",
     "prepare": "husky",
     "tree": "tree -I 'node_modules|.git|.turbo|dist|build'"
   },


### PR DESCRIPTION
## What

- Create package-specific GitHub tags and releases after a successful Changesets npm publish.
- Detect changed package manifests from the merged `changeset-release/main` PR.
- Run release creation in a separate job with scoped `contents: write` permission.
- Validate package names, versions, changelogs, npm publication, tag targets, and the verified release SHA.
- Make release creation idempotent and reject conflicting existing tags or releases.
- Add unit tests for release planning, validation, dry runs, and conflict handling.
- Include the release tests in the root verification command.
- Keep the local Git convention file untracked.

## Why

Packages were published to npm with provenance, but matching GitHub tags and releases were not created. This adds traceable release metadata without expanding the npm publishing job's permissions or introducing an npm token.

## Testing

- `pnpm test:release` — passed
- Release creation dry run — passed
- The end-to-end GitHub Actions path will be verified during the next Changesets release.

---

**Breaking?** No. This does not change any public package API and requires no migration.