### PR TITLE
fix(playground): propagate metric status to deploy job

### DIFF
--- a/.github/workflows/playground-metrics.yml
+++ b/.github/workflows/playground-metrics.yml
@@ -54,7 +54,8 @@ jobs:
         id: metric_manifest
         working-directory: apps/playground
         run: |
-          echo "current_status=$(jq -r '.scenarios[\"sync-staleness\"].currentStatus' public/metrics/manifest.json)" >> "$GITHUB_OUTPUT"
+          current_status="$(jq -er '.scenarios["sync-staleness"].currentStatus' public/metrics/manifest.json)"
+          echo "current_status=$current_status" >> "$GITHUB_OUTPUT"
 
       - name: Upload metrics artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f

--- a/apps/playground/tests/metric-artifact.test.ts
+++ b/apps/playground/tests/metric-artifact.test.ts
@@ -358,6 +358,12 @@ test('keeps the metrics directory under the deployed Pages root', async () => {
     workflow,
     /if: \$\{\{ always\(\) && needs\.metrics\.outputs\.pages_ready == 'true' \}\}/,
   );
+  assert.ok(
+    workflow.includes(
+      `current_status="$(jq -er '.scenarios["sync-staleness"].currentStatus' public/metrics/manifest.json)"`,
+    ),
+  );
+  assert.ok(!workflow.includes(`.scenarios[\\"sync-staleness\\"].currentStatus`));
   assert.match(workflow, /EXPECTED_STATUS: \$\{\{ needs\.metrics\.outputs\.current_status \}\}/);
   assert.doesNotMatch(workflow, /currentStatus' <<< "\$artifact"\)" = "passed"/);
 });


### PR DESCRIPTION
## What

- Parse the published sync-staleness status with a valid jq expression.
- Fail immediately when the manifest status cannot be read.
- Add contract assertions that prevent the invalid escaping from returning.

## Why

The escaped quotes caused jq to fail inside command substitution. The surrounding echo command hid that failure and published an
empty job output, causing the post-deployment verification to fail despite a successful Pages deployment.

## Testing

- `pnpm --filter playground test:contract`
- `pnpm --filter playground exec eslint tests/metric-artifact.test.ts`
- `git diff --check`

---

**Breaking?** No