### PR TITLE
feat(playground): publish Instant Cart benchmark artifacts

### DIFF
--- a/.github/workflows/playground-metrics.yml
+++ b/.github/workflows/playground-metrics.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       current_status: ${{ steps.metric_manifest.outputs.current_status }}
+      instant_cart_status: ${{ steps.metric_manifest.outputs.instant_cart_status }}
       pages_ready: ${{ steps.pages_artifact.outputs.pages_ready }}
     steps:
       - name: Checkout
@@ -55,7 +56,9 @@ jobs:
         working-directory: apps/playground
         run: |
           current_status="$(jq -er '.scenarios["sync-staleness"].currentStatus' public/metrics/manifest.json)"
+          instant_cart_status="$(jq -er '.scenarios["sync-instant-cart"].currentStatus' public/metrics/manifest.json)"
           echo "current_status=$current_status" >> "$GITHUB_OUTPUT"
+          echo "instant_cart_status=$instant_cart_status" >> "$GITHUB_OUTPUT"
 
       - name: Upload metrics artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
@@ -97,11 +100,20 @@ jobs:
         env:
           PAGE_URL: ${{ steps.deployment.outputs.page_url }}
           EXPECTED_STATUS: ${{ needs.metrics.outputs.current_status }}
+          EXPECTED_INSTANT_CART_STATUS: ${{ needs.metrics.outputs.instant_cart_status }}
         run: |
           manifest_url="${PAGE_URL%/}/metrics/manifest.json"
           manifest="$(curl --fail --silent --show-error --retry 5 "$manifest_url")"
           test "$(jq -r '.sourceCommit' <<< "$manifest")" = "$GITHUB_SHA"
-          artifact_path="$(jq -r '.scenarios["sync-staleness"].artifactPath' <<< "$manifest")"
-          artifact="$(curl --fail --silent --show-error --retry 5 "${PAGE_URL%/}${artifact_path}")"
-          test "$(jq -r '.source.dirty' <<< "$artifact")" = "false"
-          test "$(jq -r '.currentStatus' <<< "$artifact")" = "$EXPECTED_STATUS"
+          verify_artifact() {
+            scenario_id="$1"
+            expected_status="$2"
+            artifact_path="$(jq -r --arg scenario "$scenario_id" '.scenarios[$scenario].artifactPath' <<< "$manifest")"
+            manifest_status="$(jq -r --arg scenario "$scenario_id" '.scenarios[$scenario].currentStatus' <<< "$manifest")"
+            artifact="$(curl --fail --silent --show-error --retry 5 "${PAGE_URL%/}${artifact_path}")"
+            test "$manifest_status" = "$expected_status"
+            test "$(jq -r '.source.dirty' <<< "$artifact")" = "false"
+            test "$(jq -r '.currentStatus' <<< "$artifact")" = "$expected_status"
+          }
+          verify_artifact "sync-staleness" "$EXPECTED_STATUS"
+          verify_artifact "sync-instant-cart" "$EXPECTED_INSTANT_CART_STATUS"

--- a/apps/playground/src/lib/metric-artifact.ts
+++ b/apps/playground/src/lib/metric-artifact.ts
@@ -51,7 +51,7 @@ const samplingSchema = z.object({
   rawArtifactPath: z.string().min(1),
 });
 
-export const metricArtifactSchema = z
+const syncStalenessArtifactSchema = z
   .object({
     schemaVersion: z.literal(1),
     scenarioVersion: z.literal(1),
@@ -82,11 +82,139 @@ export const metricArtifactSchema = z
       })
       .strict(),
   })
-  .strict()
+  .strict();
+
+const instantCartEventSchema = z.enum([
+  'optimistic-patch',
+  'optimistic-paint',
+  'server-gate-released',
+  'request-started',
+  'server-gate-completed',
+  'server-acknowledged',
+]);
+
+const benchmarkMetricSchema = z
+  .object({
+    kind: z.literal('benchmark'),
+    unit: z.literal('ms'),
+    samples: z.array(z.number().finite().positive()).max(20),
+    failedSamples: z.number().int().nonnegative(),
+    median: z.number().finite().positive().nullable(),
+    p95: z.number().finite().positive().nullable(),
+  })
+  .strict();
+
+const syncInstantCartArtifactSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    scenarioVersion: z.literal(1),
+    scenarioId: z.literal('sync-instant-cart'),
+    runId: z.string().min(1),
+    source: sourceSchema,
+    build: buildSchema,
+    environment: environmentSchema,
+    sampling: z
+      .object({
+        warmupRuns: z.number().int().min(0).max(3),
+        measuredRuns: z.number().int().min(0).max(20),
+        aggregation: z.literal('median,p95'),
+        rawArtifactPath: z.string().min(1),
+      })
+      .strict(),
+    measuredAt: z.string().datetime(),
+    currentStatus: z.enum(['passed', 'failed']),
+    lastSuccessfulRunId: z.string().min(1).nullable(),
+    metrics: z
+      .object({
+        'optimistic-paint-precedes-ack': z
+          .object({
+            kind: z.literal('contract'),
+            passed: z.boolean(),
+            passedRuns: z.number().int().min(0).max(20),
+            events: z.array(instantCartEventSchema).max(6),
+          })
+          .strict(),
+        'input-to-optimistic-paint-ms': benchmarkMetricSchema,
+        'server-ack-ms': benchmarkMetricSchema,
+        'traditional-input-to-paint-ms': benchmarkMetricSchema,
+      })
+      .strict(),
+  })
+  .strict();
+
+const expectedInstantCartEvents = [
+  'optimistic-patch',
+  'optimistic-paint',
+  'server-gate-released',
+  'request-started',
+  'server-gate-completed',
+  'server-acknowledged',
+] as const;
+
+export function summarizeBenchmarkSamples(samples: number[]) {
+  if (samples.length === 0) {
+    return { median: null, p95: null };
+  }
+
+  const sorted = [...samples].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  const median =
+    sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+  const p95 = sorted[Math.ceil(sorted.length * 0.95) - 1];
+
+  return { median, p95 };
+}
+
+function validateBenchmarkMetric(
+  metric: z.infer<typeof benchmarkMetricSchema>,
+  path: string,
+  context: z.RefinementCtx,
+) {
+  const summary = summarizeBenchmarkSamples(metric.samples);
+  if (metric.median !== summary.median || metric.p95 !== summary.p95) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['metrics', path],
+      message: 'Benchmark aggregates must match the raw samples',
+    });
+  }
+}
+
+export const metricArtifactSchema = z
+  .discriminatedUnion('scenarioId', [syncStalenessArtifactSchema, syncInstantCartArtifactSchema])
   .superRefine((artifact, context) => {
-    const metricsPassed =
-      artifact.metrics['stale-mount-triggers-sync'].passed &&
-      artifact.metrics['never-mount-skips-sync'].passed;
+    let metricsPassed: boolean;
+
+    if (artifact.scenarioId === 'sync-staleness') {
+      metricsPassed =
+        artifact.metrics['stale-mount-triggers-sync'].passed &&
+        artifact.metrics['never-mount-skips-sync'].passed;
+    } else {
+      const contractMetric = artifact.metrics['optimistic-paint-precedes-ack'];
+      const benchmarkMetrics = [
+        ['input-to-optimistic-paint-ms', artifact.metrics['input-to-optimistic-paint-ms']],
+        ['server-ack-ms', artifact.metrics['server-ack-ms']],
+        ['traditional-input-to-paint-ms', artifact.metrics['traditional-input-to-paint-ms']],
+      ] as const;
+
+      for (const [path, metric] of benchmarkMetrics) {
+        validateBenchmarkMetric(metric, path, context);
+      }
+
+      const eventsMatch =
+        contractMetric.events.length === expectedInstantCartEvents.length &&
+        contractMetric.events.every((event, index) => event === expectedInstantCartEvents[index]);
+      const benchmarkComplete = benchmarkMetrics.every(
+        ([, metric]) => metric.samples.length === 20 && metric.failedSamples === 0,
+      );
+      metricsPassed =
+        contractMetric.passed &&
+        contractMetric.passedRuns === 20 &&
+        eventsMatch &&
+        artifact.sampling.warmupRuns === 3 &&
+        artifact.sampling.measuredRuns === 20 &&
+        benchmarkComplete;
+    }
 
     if ((artifact.currentStatus === 'passed') !== metricsPassed) {
       context.addIssue({
@@ -133,6 +261,11 @@ export const metricManifestSchema = z
 export type MetricArtifactStatus = z.infer<typeof metricArtifactStatusSchema>;
 export type MetricLoadIssue = z.infer<typeof metricLoadIssueSchema>;
 export type MetricArtifact = z.infer<typeof metricArtifactSchema>;
+export type SyncStalenessMetricArtifact = Extract<MetricArtifact, { scenarioId: 'sync-staleness' }>;
+export type SyncInstantCartMetricArtifact = Extract<
+  MetricArtifact,
+  { scenarioId: 'sync-instant-cart' }
+>;
 export type MetricManifest = z.infer<typeof metricManifestSchema>;
 
 export interface MetricArtifactEvaluation {

--- a/apps/playground/src/pages/sync/instant-cart.tsx
+++ b/apps/playground/src/pages/sync/instant-cart.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { flushSync } from 'react-dom';
 import { Clock, Zap, RefreshCw, Loader2 } from 'lucide-react';
 import { DemoLayout, MetricsGrid, MetricCard, SectionHeader, BeforeAfter } from '@/components/demo';
 import { useSyncedModel } from '@firsttx/local-first';
@@ -167,6 +168,8 @@ export default function InstantCart() {
     }
 
     firstTxMutationStartRef.current = start;
+    setFirstTxServerAck(null);
+    setActionLatency((previous) => ({ ...previous, firstTx: 0 }));
     setFixtureEvents([]);
     const gate = createCartRequestGate(addFixtureEvent);
     requestGateRef.current = gate;
@@ -197,12 +200,14 @@ export default function InstantCart() {
 
     const start = performance.now();
     setTraditionalUpdating(true);
+    setActionLatency((previous) => ({ ...previous, traditional: 0 }));
 
     try {
       const item = traditionalCart.items.find((i) => i.id === itemId);
       if (item) {
         const newCart = await updateCartItem(itemId, item.quantity + 1);
-        setTraditionalCart(newCart);
+        flushSync(() => setTraditionalCart(newCart));
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
         const end = performance.now();
         setActionLatency((prev) => ({ ...prev, traditional: end - start }));
       }

--- a/apps/playground/tests/README.md
+++ b/apps/playground/tests/README.md
@@ -61,7 +61,7 @@ pnpm --filter playground exec playwright test \
 
 ## 측정 결과
 
-측정값을 기록하는 테스트는 `tests/utils/metrics.ts`를 사용하며 저장소 루트의 `.metrics/`에 결과를 생성합니다. `sync-staleness`는 source, package fingerprint, 실행 환경, 측정 시각과 current/last-success 상태를 포함하는 schema v1 artifact를 생성합니다. 기존 benchmark 파일은 schema 전환 전까지 legacy로 분리합니다.
+측정값을 기록하는 테스트는 `tests/utils/metrics.ts`를 사용하며 저장소 루트의 `.metrics/`에 결과를 생성합니다. `sync-staleness`와 `sync-instant-cart`는 source, package fingerprint, 실행 환경, 측정 시각과 current/last-success 상태를 포함하는 schema v1 artifact를 생성합니다. Instant Cart benchmark는 3회 warm-up 뒤 20개 raw sample, 실패 sample 수, median과 nearest-rank p95를 기록합니다. 기존 benchmark 파일은 schema 전환 전까지 legacy로 분리합니다.
 
 다음 명령은 schema 검증을 통과한 artifact를 immutable run 경로에 게시하고 `public/metrics/manifest.json`을 마지막에 교체합니다. main workflow는 실패한 contract artifact도 게시한 뒤 job 실패를 복원하며, publisher는 이전 manifest의 마지막 성공 run ID를 계승합니다.
 

--- a/apps/playground/tests/instant-cart.metrics.spec.ts
+++ b/apps/playground/tests/instant-cart.metrics.spec.ts
@@ -1,65 +1,161 @@
-import { test, expect, Page } from '@playwright/test';
-import { createMetricRecord, writeMetrics } from './utils/metrics';
+import { expect, test, type Page } from '@playwright/test';
+import { createInstantCartArtifact, writeMetrics } from './utils/metrics';
 
-async function readMetricsAttributes(page: Page) {
-  return page.locator('[data-testid="instant-cart-metrics"]').evaluate((node) => {
-    return {
-      firstTxInitial: node.getAttribute('data-firsttx-initial'),
-      traditionalInitial: node.getAttribute('data-traditional-initial'),
-      firstTxAction: node.getAttribute('data-firsttx-action'),
-      traditionalAction: node.getAttribute('data-traditional-action'),
-      firstTxServerAck: node.getAttribute('data-firsttx-server-ack'),
-      timeSaved: node.getAttribute('data-time-saved'),
-    };
-  });
+const warmupRunCount = 3;
+const measuredRunCount = 20;
+const expectedEvents = [
+  'optimistic-patch',
+  'optimistic-paint',
+  'server-gate-released',
+  'request-started',
+  'server-gate-completed',
+  'server-acknowledged',
+] as const;
+
+interface InstantCartSample {
+  inputToOptimisticPaintMs: number;
+  serverAckMs: number;
+  traditionalInputToPaintMs: number;
+  events: string[];
+}
+
+async function readPositiveAttribute(page: Page, name: string) {
+  const metrics = page.getByTestId('instant-cart-metrics');
+  await expect
+    .poll(async () => Number(await metrics.getAttribute(name)), { timeout: 10_000 })
+    .toBeGreaterThan(0);
+  return Number(await metrics.getAttribute(name));
+}
+
+async function measureInstantCart(page: Page): Promise<InstantCartSample> {
+  const traditionalButton = page.getByTestId('traditional-increment-1');
+  const traditionalQuantity = page.getByTestId('traditional-increment-quantity-1');
+  const traditionalBefore = Number(await traditionalQuantity.textContent());
+  await traditionalButton.click();
+  await expect(traditionalQuantity).toHaveText(String(traditionalBefore + 1), { timeout: 10_000 });
+  const traditionalInputToPaintMs = await readPositiveAttribute(page, 'data-traditional-action');
+  await expect(traditionalButton).toBeEnabled();
+
+  const firstTxButton = page.getByTestId('firsttx-increment-1');
+  const firstTxQuantity = page.getByTestId('firsttx-increment-quantity-1');
+  const firstTxBefore = Number(await firstTxQuantity.textContent());
+  await firstTxButton.click();
+  await expect(firstTxQuantity).toHaveText(String(firstTxBefore + 1));
+  const events = page.getByTestId('instant-cart-events').locator('li');
+  await expect(events).toHaveText(['optimistic-patch', 'optimistic-paint']);
+  const inputToOptimisticPaintMs = await readPositiveAttribute(page, 'data-firsttx-action');
+
+  await page.getByTestId('release-instant-cart-server').click();
+  await expect(events).toHaveText([...expectedEvents]);
+  const serverAckMs = await readPositiveAttribute(page, 'data-firsttx-server-ack');
+  await expect(page.getByTestId('instant-cart-fixture')).toBeEnabled();
+
+  return {
+    inputToOptimisticPaintMs,
+    serverAckMs,
+    traditionalInputToPaintMs,
+    events: await events.allTextContents(),
+  };
 }
 
 test.describe('Instant Cart metrics', () => {
-  test('collects latency comparisons', async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+
+  let completedWarmups = 0;
+  let failedSamples = 0;
+  let passedRuns = 0;
+  let latestEvents: string[] = [];
+  let inputToOptimisticPaintMs: number[] = [];
+  let serverAckMs: number[] = [];
+  let traditionalInputToPaintMs: number[] = [];
+
+  test.beforeEach(() => {
+    completedWarmups = 0;
+    failedSamples = 0;
+    passedRuns = 0;
+    latestEvents = [];
+    inputToOptimisticPaintMs = [];
+    serverAckMs = [];
+    traditionalInputToPaintMs = [];
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    if (testInfo.status === testInfo.expectedStatus) {
+      return;
+    }
+
+    const viewport = page.viewportSize() ?? { width: 1280, height: 720 };
+    const dpr = page.isClosed()
+      ? 1
+      : await page.evaluate(() => window.devicePixelRatio).catch(() => 1);
+    const artifact = await createInstantCartArtifact(
+      {
+        warmupRuns: completedWarmups,
+        failedSamples: Math.max(failedSamples, 1),
+        passedRuns,
+        events: latestEvents as (typeof expectedEvents)[number][],
+        inputToOptimisticPaintMs,
+        serverAckMs,
+        traditionalInputToPaintMs,
+      },
+      {
+        browser: testInfo.project.name,
+        viewport,
+        dpr,
+      },
+    );
+    await writeMetrics(artifact);
+  });
+
+  test('publishes 3 warm-up and 20 measured latency samples', async ({ page }, testInfo) => {
     await page.addInitScript(() => {
       window.sessionStorage.setItem('firsttx:autoLoadTraditional', '1');
     });
     await page.goto('/sync/instant-cart');
-
-    const traditionalPlus = page.getByTestId('traditional-increment-1');
-    await traditionalPlus.waitFor({ state: 'visible', timeout: 20_000 });
-    await traditionalPlus.click();
-
+    await expect(page.getByTestId('traditional-increment-1')).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByTestId('firsttx-increment-1')).toBeVisible({ timeout: 20_000 });
     await page.getByTestId('instant-cart-fixture').selectOption('ack');
-    const firstTxPlus = page.getByTestId('firsttx-increment-1');
-    await firstTxPlus.waitFor({ state: 'visible', timeout: 20_000 });
-    await firstTxPlus.click();
 
-    const metricsElement = page.getByTestId('instant-cart-metrics');
-    await expect(metricsElement).toHaveAttribute('data-firsttx-action', /.+/, { timeout: 10_000 });
-    await page.getByTestId('release-instant-cart-server').click();
-    await expect(page.getByTestId('instant-cart-events').locator('li')).toHaveText([
-      'optimistic-patch',
-      'optimistic-paint',
-      'server-gate-released',
-      'request-started',
-      'server-gate-completed',
-      'server-acknowledged',
-    ]);
-    await expect(metricsElement).toHaveAttribute('data-firsttx-server-ack', /.+/);
-    await expect(metricsElement).toHaveAttribute('data-traditional-action', /.+/);
+    for (let index = 0; index < warmupRunCount + measuredRunCount; index += 1) {
+      let sample: InstantCartSample;
+      try {
+        sample = await measureInstantCart(page);
+      } catch (error) {
+        failedSamples += 1;
+        throw error;
+      }
 
-    const attrs = await readMetricsAttributes(page);
+      latestEvents = sample.events;
+      if (index < warmupRunCount) {
+        completedWarmups += 1;
+        continue;
+      }
 
-    const metrics = {
-      firstTxInitialLoadMs: Number(attrs.firstTxInitial ?? 0),
-      traditionalInitialLoadMs: Number(attrs.traditionalInitial ?? 0),
-      firstTxActionLatency: Number(attrs.firstTxAction ?? 0),
-      traditionalActionLatency: Number(attrs.traditionalAction ?? 0),
-      firstTxServerAckMs: Number(attrs.firstTxServerAck ?? 0),
-      timeSavedPerInteraction: Number(attrs.timeSaved ?? 0),
-    };
+      passedRuns += 1;
+      inputToOptimisticPaintMs.push(sample.inputToOptimisticPaintMs);
+      serverAckMs.push(sample.serverAckMs);
+      traditionalInputToPaintMs.push(sample.traditionalInputToPaintMs);
+    }
 
-    await writeMetrics(
-      createMetricRecord('instant-cart', metrics, {
-        project: testInfo.project.name,
-        url: '/sync/instant-cart',
-      }),
+    const viewport = page.viewportSize() ?? { width: 1280, height: 720 };
+    const artifact = await createInstantCartArtifact(
+      {
+        warmupRuns: completedWarmups,
+        failedSamples,
+        passedRuns,
+        events: latestEvents as (typeof expectedEvents)[number][],
+        inputToOptimisticPaintMs,
+        serverAckMs,
+        traditionalInputToPaintMs,
+      },
+      {
+        browser: testInfo.project.name,
+        viewport,
+        dpr: await page.evaluate(() => window.devicePixelRatio),
+      },
     );
+    await writeMetrics(artifact);
+
+    expect(artifact.currentStatus).toBe('passed');
   });
 });

--- a/apps/playground/tests/metric-artifact.test.ts
+++ b/apps/playground/tests/metric-artifact.test.ts
@@ -10,7 +10,11 @@ import {
   carryForwardLastSuccessfulRun,
   evaluateMetricArtifact,
   metricArtifactSchema,
+  metricManifestSchema,
+  summarizeBenchmarkSamples,
   type MetricArtifact,
+  type SyncInstantCartMetricArtifact,
+  type SyncStalenessMetricArtifact,
 } from '../src/lib/metric-artifact.ts';
 import { loadMetricFeed } from '../src/lib/metric-feed.ts';
 
@@ -19,7 +23,7 @@ const measuredAt = '2026-07-22T08:00:00.000Z';
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const execFileAsync = promisify(execFile);
 
-function createArtifact(): MetricArtifact {
+function createArtifact(): SyncStalenessMetricArtifact {
   return {
     schemaVersion: 1,
     scenarioVersion: 1,
@@ -74,7 +78,9 @@ function createArtifact(): MetricArtifact {
   };
 }
 
-function createFailedArtifact(lastSuccessfulRunId: string | null = null): MetricArtifact {
+function createFailedArtifact(
+  lastSuccessfulRunId: string | null = null,
+): SyncStalenessMetricArtifact {
   const artifact = createArtifact();
   artifact.currentStatus = 'failed';
   artifact.lastSuccessfulRunId = lastSuccessfulRunId;
@@ -84,18 +90,96 @@ function createFailedArtifact(lastSuccessfulRunId: string | null = null): Metric
   return artifact;
 }
 
-function createManifest(artifact: MetricArtifact) {
+function createBenchmarkMetric(samples: number[]) {
+  return {
+    kind: 'benchmark' as const,
+    unit: 'ms' as const,
+    samples,
+    failedSamples: 0,
+    ...summarizeBenchmarkSamples(samples),
+  };
+}
+
+function createInstantCartArtifact(): SyncInstantCartMetricArtifact {
+  const inputSamples = Array.from({ length: 20 }, (_, index) => index + 1);
+  const acknowledgementSamples = Array.from({ length: 20 }, (_, index) => index + 21);
+  const traditionalSamples = Array.from({ length: 20 }, (_, index) => index + 501);
+
   return {
     schemaVersion: 1,
-    publishedAt: artifact.measuredAt,
-    sourceCommit: artifact.source.commitSha,
-    scenarios: {
-      'sync-staleness': {
-        artifactPath: '/metrics/runs/fixture/sync-staleness.json',
+    scenarioVersion: 1,
+    scenarioId: 'sync-instant-cart',
+    runId: measuredAt,
+    source: {
+      commitSha: sourceCommit,
+      dirty: false,
+    },
+    build: {
+      appVersion: '0.0.0',
+      packages: {
+        '@firsttx/local-first': '0.11.4',
+        '@firsttx/tx': '0.8.2',
+      },
+      fingerprint: 'instant-cart-fixture',
+    },
+    environment: {
+      browser: 'chromium',
+      os: 'linux',
+      viewport: {
+        width: 1280,
+        height: 720,
+      },
+      dpr: 1,
+      cpuProfile: 'uncontrolled',
+      networkProfile: 'uncontrolled',
+    },
+    sampling: {
+      warmupRuns: 3,
+      measuredRuns: 20,
+      aggregation: 'median,p95',
+      rawArtifactPath: 'playwright-report/instant-cart',
+    },
+    measuredAt,
+    currentStatus: 'passed',
+    lastSuccessfulRunId: measuredAt,
+    metrics: {
+      'optimistic-paint-precedes-ack': {
+        kind: 'contract',
+        passed: true,
+        passedRuns: 20,
+        events: [
+          'optimistic-patch',
+          'optimistic-paint',
+          'server-gate-released',
+          'request-started',
+          'server-gate-completed',
+          'server-acknowledged',
+        ],
+      },
+      'input-to-optimistic-paint-ms': createBenchmarkMetric(inputSamples),
+      'server-ack-ms': createBenchmarkMetric(acknowledgementSamples),
+      'traditional-input-to-paint-ms': createBenchmarkMetric(traditionalSamples),
+    },
+  };
+}
+
+function createManifest(...artifacts: MetricArtifact[]) {
+  const scenarios = Object.fromEntries(
+    artifacts.map((artifact) => [
+      artifact.scenarioId,
+      {
+        artifactPath: `/metrics/runs/fixture/${artifact.scenarioId}.json`,
         currentStatus: artifact.currentStatus,
         lastSuccessfulRunId: artifact.lastSuccessfulRunId,
       },
-    },
+    ]),
+  );
+
+  return {
+    schemaVersion: 1,
+    publishedAt: artifacts[0]?.measuredAt ?? measuredAt,
+    sourceCommit: artifacts[0]?.source.commitSha ?? sourceCommit,
+    scenarios,
   };
 }
 
@@ -108,6 +192,20 @@ function createFetcher(responses: Record<string, Response>) {
 
 test('accepts the sync-staleness contract artifact', () => {
   assert.equal(metricArtifactSchema.safeParse(createArtifact()).success, true);
+});
+
+test('accepts a complete Instant Cart contract and benchmark artifact', () => {
+  assert.equal(metricArtifactSchema.safeParse(createInstantCartArtifact()).success, true);
+});
+
+test('rejects incomplete Instant Cart samples and incorrect aggregates', () => {
+  const incomplete = createInstantCartArtifact();
+  incomplete.metrics['input-to-optimistic-paint-ms'].samples.pop();
+  assert.equal(metricArtifactSchema.safeParse(incomplete).success, false);
+
+  const incorrectAggregate = createInstantCartArtifact();
+  incorrectAggregate.metrics['server-ack-ms'].p95 = 1;
+  assert.equal(metricArtifactSchema.safeParse(incorrectAggregate).success, false);
 });
 
 test('rejects missing provenance and unknown metric ids', () => {
@@ -191,11 +289,12 @@ test('carries the previous successful run across a failed current run', () => {
   assert.equal(passed.lastSuccessfulRunId, passed.runId);
 });
 
-test('publisher carries last-success into a failed immutable artifact', async () => {
+test('publisher carries last-success and publishes multiple schema v1 artifacts', async () => {
   const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'firsttx-metrics-'));
   const metricsDir = path.join(temporaryRoot, 'input');
   const publicMetricsDir = path.join(temporaryRoot, 'public', 'metrics');
   const artifact = createFailedArtifact();
+  const instantCartArtifact = createInstantCartArtifact();
   const previousArtifact = createArtifact();
   previousArtifact.runId = 'previous-run';
   previousArtifact.lastSuccessfulRunId = 'previous-run';
@@ -206,6 +305,11 @@ test('publisher carries last-success into a failed immutable artifact', async ()
     await writeFile(
       path.join(metricsDir, 'sync-staleness.latest.json'),
       JSON.stringify(artifact),
+      'utf-8',
+    );
+    await writeFile(
+      path.join(metricsDir, 'sync-instant-cart.latest.json'),
+      JSON.stringify(instantCartArtifact),
       'utf-8',
     );
     await writeFile(
@@ -231,9 +335,9 @@ test('publisher carries last-success into a failed immutable artifact', async ()
       },
     );
 
-    const manifest = JSON.parse(
-      await readFile(path.join(publicMetricsDir, 'manifest.json'), 'utf-8'),
-    ) as ReturnType<typeof createManifest>;
+    const manifest = metricManifestSchema.parse(
+      JSON.parse(await readFile(path.join(publicMetricsDir, 'manifest.json'), 'utf-8')),
+    );
     const manifestEntry = manifest.scenarios['sync-staleness'];
     const publishedArtifact = metricArtifactSchema.parse(
       JSON.parse(
@@ -243,11 +347,29 @@ test('publisher carries last-success into a failed immutable artifact', async ()
         ),
       ),
     );
+    const instantCartManifestEntry = manifest.scenarios['sync-instant-cart'];
+    const publishedInstantCartArtifact = metricArtifactSchema.parse(
+      JSON.parse(
+        await readFile(
+          path.join(
+            publicMetricsDir,
+            instantCartManifestEntry.artifactPath.replace('/metrics/', ''),
+          ),
+          'utf-8',
+        ),
+      ),
+    );
 
     assert.equal(manifestEntry.currentStatus, 'failed');
     assert.equal(manifestEntry.lastSuccessfulRunId, previousArtifact.runId);
     assert.equal(publishedArtifact.currentStatus, 'failed');
     assert.equal(publishedArtifact.lastSuccessfulRunId, previousArtifact.runId);
+    assert.equal(instantCartManifestEntry.currentStatus, 'passed');
+    assert.equal(
+      instantCartManifestEntry.lastSuccessfulRunId,
+      instantCartArtifact.lastSuccessfulRunId,
+    );
+    assert.equal(publishedInstantCartArtifact.scenarioId, 'sync-instant-cart');
   } finally {
     await rm(temporaryRoot, { recursive: true, force: true });
   }
@@ -255,20 +377,27 @@ test('publisher carries last-success into a failed immutable artifact', async ()
 
 test('loads a valid feed and leaves unreported scenarios not measured', async () => {
   const artifact = createArtifact();
+  const instantCartArtifact = createInstantCartArtifact();
   const baseUrl = 'https://metrics.example.test';
   const scenarios = await loadMetricFeed({
     baseUrl,
     currentSourceRevision: sourceCommit,
-    scenarioIds: ['sync-staleness', 'sync-suspense'],
+    scenarioIds: ['sync-staleness', 'sync-instant-cart', 'sync-suspense'],
     fetcher: createFetcher({
-      [`${baseUrl}/metrics/manifest.json`]: Response.json(createManifest(artifact)),
+      [`${baseUrl}/metrics/manifest.json`]: Response.json(
+        createManifest(artifact, instantCartArtifact),
+      ),
       [`${baseUrl}/metrics/runs/fixture/sync-staleness.json`]: Response.json(artifact),
+      [`${baseUrl}/metrics/runs/fixture/sync-instant-cart.json`]:
+        Response.json(instantCartArtifact),
     }),
     now: Date.parse(measuredAt),
   });
 
   assert.equal(scenarios['sync-staleness']?.status, 'passed');
   assert.equal(scenarios['sync-staleness']?.issue, null);
+  assert.equal(scenarios['sync-instant-cart']?.status, 'passed');
+  assert.equal(scenarios['sync-instant-cart']?.issue, null);
   assert.equal(scenarios['sync-suspense']?.status, 'not-measured');
   assert.equal(scenarios['sync-suspense']?.issue, 'unreported');
 });
@@ -363,7 +492,17 @@ test('keeps the metrics directory under the deployed Pages root', async () => {
       `current_status="$(jq -er '.scenarios["sync-staleness"].currentStatus' public/metrics/manifest.json)"`,
     ),
   );
+  assert.ok(
+    workflow.includes(
+      `instant_cart_status="$(jq -er '.scenarios["sync-instant-cart"].currentStatus' public/metrics/manifest.json)"`,
+    ),
+  );
   assert.ok(!workflow.includes(`.scenarios[\\"sync-staleness\\"].currentStatus`));
   assert.match(workflow, /EXPECTED_STATUS: \$\{\{ needs\.metrics\.outputs\.current_status \}\}/);
+  assert.match(
+    workflow,
+    /EXPECTED_INSTANT_CART_STATUS: \$\{\{ needs\.metrics\.outputs\.instant_cart_status \}\}/,
+  );
+  assert.match(workflow, /verify_artifact "sync-instant-cart" "\$EXPECTED_INSTANT_CART_STATUS"/);
   assert.doesNotMatch(workflow, /currentStatus' <<< "\$artifact"\)" = "passed"/);
 });

--- a/apps/playground/tests/utils/metrics.ts
+++ b/apps/playground/tests/utils/metrics.ts
@@ -4,7 +4,13 @@ import { execFile } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { metricArtifactSchema, type MetricArtifact } from '../../src/lib/metric-artifact';
+import {
+  metricArtifactSchema,
+  summarizeBenchmarkSamples,
+  type MetricArtifact,
+  type SyncInstantCartMetricArtifact,
+  type SyncStalenessMetricArtifact,
+} from '../../src/lib/metric-artifact';
 
 export interface MetricRecord {
   scenario: string;
@@ -65,6 +71,24 @@ async function readPackageVersion(relativePath: string) {
   return packageJson.version;
 }
 
+async function readBuild(sourceCommit: string) {
+  const packages = {
+    '@firsttx/local-first': await readPackageVersion('packages/local-first/package.json'),
+    '@firsttx/prepaint': await readPackageVersion('packages/prepaint/package.json'),
+    '@firsttx/tx': await readPackageVersion('packages/tx/package.json'),
+  };
+  const appVersion = await readPackageVersion('apps/playground/package.json');
+  const fingerprint = createHash('sha256')
+    .update(JSON.stringify({ appVersion, packages, source: sourceCommit }))
+    .digest('hex');
+
+  return {
+    appVersion,
+    packages,
+    fingerprint,
+  };
+}
+
 async function getSource() {
   const commitSha =
     process.env.GITHUB_SHA ??
@@ -84,18 +108,10 @@ async function getSource() {
 export async function createSyncStalenessArtifact(
   values: SyncStalenessMetricValues,
   environment: MetricEnvironment,
-): Promise<MetricArtifact> {
+): Promise<SyncStalenessMetricArtifact> {
   const measuredAt = new Date().toISOString();
   const source = await getSource();
-  const packages = {
-    '@firsttx/local-first': await readPackageVersion('packages/local-first/package.json'),
-    '@firsttx/prepaint': await readPackageVersion('packages/prepaint/package.json'),
-    '@firsttx/tx': await readPackageVersion('packages/tx/package.json'),
-  };
-  const appVersion = await readPackageVersion('apps/playground/package.json');
-  const fingerprint = createHash('sha256')
-    .update(JSON.stringify({ appVersion, packages, source: source.commitSha }))
-    .digest('hex');
+  const build = await readBuild(source.commitSha);
   const staleMountPassed = values.staleMount.fetchCount === 1 && !values.staleMount.isStale;
   const neverMountPassed =
     values.neverMount.automaticFetchCount === 0 &&
@@ -109,11 +125,7 @@ export async function createSyncStalenessArtifact(
     scenarioId: 'sync-staleness',
     runId: measuredAt,
     source,
-    build: {
-      appVersion,
-      packages,
-      fingerprint,
-    },
+    build,
     environment: {
       browser: environment.browser,
       os: process.platform,
@@ -146,5 +158,95 @@ export async function createSyncStalenessArtifact(
         isStale: values.neverMount.isStale,
       },
     },
-  });
+  }) as SyncStalenessMetricArtifact;
+}
+
+interface InstantCartMetricValues {
+  warmupRuns: number;
+  failedSamples: number;
+  passedRuns: number;
+  events: SyncInstantCartMetricArtifact['metrics']['optimistic-paint-precedes-ack']['events'];
+  inputToOptimisticPaintMs: number[];
+  serverAckMs: number[];
+  traditionalInputToPaintMs: number[];
+}
+
+function createBenchmarkMetric(samples: number[], failedSamples: number) {
+  const summary = summarizeBenchmarkSamples(samples);
+  return {
+    kind: 'benchmark' as const,
+    unit: 'ms' as const,
+    samples,
+    failedSamples,
+    ...summary,
+  };
+}
+
+export async function createInstantCartArtifact(
+  values: InstantCartMetricValues,
+  environment: MetricEnvironment,
+): Promise<SyncInstantCartMetricArtifact> {
+  const sampleCounts = [
+    values.inputToOptimisticPaintMs.length,
+    values.serverAckMs.length,
+    values.traditionalInputToPaintMs.length,
+  ];
+  if (new Set(sampleCounts).size !== 1) {
+    throw new Error('Instant Cart benchmark metrics must have equal sample counts');
+  }
+
+  const measuredAt = new Date().toISOString();
+  const source = await getSource();
+  const build = await readBuild(source.commitSha);
+  const measuredRuns = sampleCounts[0];
+  const currentStatus =
+    values.warmupRuns === 3 &&
+    measuredRuns === 20 &&
+    values.failedSamples === 0 &&
+    values.passedRuns === 20
+      ? 'passed'
+      : 'failed';
+
+  return metricArtifactSchema.parse({
+    schemaVersion: 1,
+    scenarioVersion: 1,
+    scenarioId: 'sync-instant-cart',
+    runId: measuredAt,
+    source,
+    build,
+    environment: {
+      browser: environment.browser,
+      os: process.platform,
+      viewport: environment.viewport,
+      dpr: environment.dpr,
+      cpuProfile: 'uncontrolled',
+      networkProfile: 'uncontrolled',
+    },
+    sampling: {
+      warmupRuns: values.warmupRuns,
+      measuredRuns,
+      aggregation: 'median,p95',
+      rawArtifactPath: 'playwright-report/instant-cart',
+    },
+    measuredAt,
+    currentStatus,
+    lastSuccessfulRunId: currentStatus === 'passed' ? measuredAt : null,
+    metrics: {
+      'optimistic-paint-precedes-ack': {
+        kind: 'contract',
+        passed: values.passedRuns === measuredRuns && measuredRuns > 0,
+        passedRuns: values.passedRuns,
+        events: values.events,
+      },
+      'input-to-optimistic-paint-ms': createBenchmarkMetric(
+        values.inputToOptimisticPaintMs,
+        values.failedSamples,
+      ),
+      'server-ack-ms': createBenchmarkMetric(values.serverAckMs, values.failedSamples),
+      'traditional-input-to-paint-ms': createBenchmarkMetric(
+        values.traditionalInputToPaintMs,
+        values.failedSamples,
+      ),
+    },
+  }) as SyncInstantCartMetricArtifact;
 }

--- a/docs/playground-contract.md
+++ b/docs/playground-contract.md
@@ -60,6 +60,7 @@
 - `contract`: 독립 model namespace, reset된 storage, seeded fixture 또는 deferred gate에서 1회 이상 실행하며 모든 assertion이 통과해야 합니다. retry로 성공을 덮지 않습니다.
 - `expected-limitation`: 지원하지 않는 상태를 고정 fixture로 최소 1회 재현하고 관찰값·설명·테스트 기대값이 모두 같아야 합니다.
 - `benchmark`: 3회 warm-up 후 20 measured samples를 수집하고 `median`과 `p95`를 게시합니다. raw samples와 실패 sample 수를 artifact에 남깁니다.
+- `median`은 정렬된 표본의 중앙 두 값 평균, `p95`는 정렬된 표본의 nearest-rank 95번째 백분위로 계산합니다.
 - benchmark baseline이 승인되기 전에는 절대 target을 홍보하지 않습니다. 승인 후 동일 runner에서 median 15% 초과 또는 p95 20% 초과 회귀가 3회 연속 발생하면 `degraded`로 판정합니다.
 
 ### 환경과 freshness
@@ -119,7 +120,7 @@ UI status는 `passed`, `failed`, `expected-limitation`, `not-measured`, `stale`,
 
 ## 후속 범위
 
-P0-A와 metric 분류는 확정했습니다. 2026.07.22 P0-E vertical slice에서 GitHub Pages를 canonical metric host로 확정하고 `sync-staleness` schema v1 artifact·manifest·loader·Lab 연결, 실패 run 게시와 last-success 계승, Pages publish workflow를 구현했습니다. 실제 `main` 배포 관찰과 나머지 scenario 전환은 아직 남아 있습니다.
+P0-A와 metric 분류는 확정했습니다. 2026.07.22 P0-E vertical slice에서 GitHub Pages를 canonical metric host로 확정하고 `sync-staleness` schema v1 artifact·manifest·loader·Lab 연결, 실패 run 게시와 last-success 계승, Pages publish workflow를 구현했습니다. 2026.07.25 `main` source revision `12f295aa33eede4b9c5893932d114de4cc918e13`의 [Playground Metrics #103](https://github.com/joseph0926/firsttx/actions/runs/30142953400)에서 schema v1 artifact 게시, Pages deploy와 source/deep-link smoke를 관찰했고 게시 artifact의 `dirty: false`, `currentStatus: passed`를 확인했습니다. 나머지 scenario 전환은 아직 남아 있습니다.
 
 - 나머지 scenario의 schema v1 artifact 전환과 production post-deploy 확인: P0-E
 - deterministic scheduler와 scenario fixture 구현: P0-F

--- a/docs/update-plan.md
+++ b/docs/update-plan.md
@@ -162,7 +162,9 @@ Playground 단독 `pnpm dev`는 Vite만 실행하지만 workspace package는 `di
 
 #### P0-E. metric loader, artifact publish와 CI 흐름 수정
 
-> 상태: 2026.07.22 `sync-staleness` vertical slice 구현 완료, P0-E 전체는 진행 중. GitHub Pages를 canonical metric host로 확정하고 schema v1 artifact·manifest, source/freshness 판정 loader, `/lab` current/last-success 상태, PR contract gate, 실패 run 게시 뒤 CI 실패 복원, Pages atomic deploy와 post-deploy source/deep-link smoke를 연결했습니다. Node 24 contract test 13개, Playground와 Playwright source typecheck, lint와 격리 publisher 실행이 통과했습니다. 실제 `main` Pages 배포와 production smoke는 아직 관찰하지 않았고 나머지 8개 scenario는 `not-measured` 또는 legacy이므로 P0-E를 완료로 닫지 않습니다.
+> 상태: 2026.07.22 `sync-staleness` vertical slice 구현 완료, P0-E 전체는 진행 중. GitHub Pages를 canonical metric host로 확정하고 schema v1 artifact·manifest, source/freshness 판정 loader, `/lab` current/last-success 상태, PR contract gate, 실패 run 게시 뒤 CI 실패 복원, Pages atomic deploy와 post-deploy source/deep-link smoke를 연결했습니다. Node 24 contract test 13개, Playground와 Playwright source typecheck, lint와 격리 publisher 실행이 통과했습니다.
+>
+> Production evidence: 2026.07.25 `main` source revision `12f295aa33eede4b9c5893932d114de4cc918e13`의 [Playground Metrics #103](https://github.com/joseph0926/firsttx/actions/runs/30142953400)에서 package build 5/5, metric contract 13/13, Chromium metric suite 5/5, schema v1 artifact 게시, GitHub Pages deploy와 post-deploy source/deep-link smoke가 통과했습니다. 게시 manifest와 `sync-staleness` artifact는 같은 source revision, `dirty: false`, `currentStatus: passed`를 확인했습니다. 나머지 8개 scenario는 `not-measured` 또는 legacy이므로 P0-E를 완료로 닫지 않습니다.
 
 - canonical metric host와 app/metric deploy owner를 확정합니다.
 - same-origin 또는 cross-origin 경로, CORS, cache-control, stale cutoff와 fallback을 테스트합니다.


### PR DESCRIPTION
## What

- Record the successful `sync-staleness` production deployment from Playground Metrics "103".
- Add a schema v1 artifact variant for `sync-instant-cart`.
- Collect 3 warm-up runs and 20 measured samples for optimistic paint, server acknowledgement, and traditional paint latency.
- Publish raw samples, failed sample counts, median, and nearest-rank p95.
- Preserve partial failed runs as failed artifacts.
- Publish and load both schema v1 scenarios through the shared manifest.
- Verify both artifacts during the GitHub Pages post-deploy smoke.

## Why

P0-E previously published only `sync-staleness` as a current schema v1 artifact. Instant Cart still emitted a legacy single-run record that could not prove the documented sampling, aggregation, provenance, or failure-state contract.

## Testing

- `pnpm --filter playground build` — passed
- `pnpm --filter playground lint` — 0 errors, 1 existing warning
- `pnpm --filter playground test:contract` — 15/15 passed
- `pnpm --filter playground test:e2e tests/prepaint-heavy.spec.ts tests/instant-cart.metrics.spec.ts tests/sync-staleness.spec.ts tests/tx-concurrent.metrics.spec.ts --reporter=line` — 5/5 passed
- Isolated `metrics:sync` — published 2 schema v1 artifacts
- Prettier check — passed
- `git diff --check` — passed
- `actionlint` — not run because it is unavailable locally

---

**Breaking?** No. The artifact schema change is additive, and existing `sync-staleness` schema v1 artifacts remain valid.