### PR TITLE
docs(rag): add index defense plan and task spec

### DIFF
--- a/docs/plans/2026-08-07-rag-defense-plan.md
+++ b/docs/plans/2026-08-07-rag-defense-plan.md
@@ -1,0 +1,367 @@
+# FirstTx Docs RAG defense plan
+
+- 상태: 계획 확정, 구현 미시작
+- 작성일: 2026-08-07
+- 대상: `apps/docs`의 canonical content, indexing, retrieval, Chat 보조 경로와 운영 관찰 surface
+- 우선순위: P0 lifecycle defense, P1 운영 편의
+- 첫 구현 task: [deterministic index plan SPEC](../spec-packets/2026-08-07-deterministic-index-plan.md)
+
+## 문서 역할
+
+이 문서는 FirstTx Docs RAG를 실패에 안전하고 반복 검증 가능한 운영 경로로 바꾸는 전체 실행 계획이다. 2026-08-06 외부 계획에서 FirstTx가 소유할 engineering 범위만 가져와 현재 source와 대조했다. 채용, 이력서, 면접과 같은 다른 저장소의 관심사는 포함하지 않는다.
+
+각 구현 task는 별도 SPEC packet으로 Goal, Scope, Domain contract, Acceptance와 Verification을 먼저 고정한다. 이 계획은 task 순서와 전체 완료 조건을 소유하며, 개별 task의 최신 구현 계약은 연결된 SPEC packet이 소유한다.
+
+## 문제 정의
+
+현재 RAG는 canonical MDX를 정규화하고 locale별로 chunk와 embedding을 만든 뒤 Upstash Vector의 `ko`, `en` namespace에 저장한다. Chat runtime은 같은 locale namespace를 직접 검색한다.
+
+현재 indexing 명령은 embedding cache를 전체 삭제하고 활성 namespace를 reset한 뒤 upsert한다. reset 이후 embedding 또는 upsert가 실패하면 사용자가 읽는 index가 비거나 부분 상태가 될 수 있다. 또한 어떤 content revision이 활성인지, 마지막 run이 왜 실패했는지, 실제 query가 어떤 문서를 검색했는지, 고정 질문에서 retrieval 품질이 유지되는지를 확인할 durable artifact가 없다.
+
+이 계획의 핵심은 새 chatbot을 만드는 것이 아니라 다음 producer-consumer 경로를 방어하는 것이다.
+
+```text
+canonical MDX
+  -> normalize + chunk
+  -> deterministic content revision
+  -> versioned staging namespace
+  -> count + metadata + retrieval validation
+  -> active pointer 전환
+  -> runtime retrieval
+  -> prompt context
+
+IndexRun + ActiveIndexPointer
+  -> read-only status API
+  -> retrieval inspector
+  -> fixed-case evaluation
+```
+
+## 현재 기준선
+
+| 경로                                   | 현재 책임                               | 기준선                                                            |
+| -------------------------------------- | --------------------------------------- | ----------------------------------------------------------------- |
+| `apps/docs/content/docs/*.{ko,en}.mdx` | 화면과 RAG가 공유하는 canonical content | 9개 document id의 KO/EN pair 18개                                 |
+| `apps/docs/scripts/canonical-mdx.ts`   | MDX normalization                       | 화면 전용 metadata와 JSX를 검색 가능한 Markdown으로 변환          |
+| `apps/docs/scripts/chunk-md.ts`        | chunking                                | H1/H2/H3 경계, 최소 100자, 최대 2,000자                           |
+| `apps/docs/scripts/main.ts`            | indexing orchestration                  | cache 삭제 후 locale별 reset, embedding, upsert                   |
+| `apps/docs/scripts/vector.ts`          | vector mutation                         | locale namespace reset, batch upsert, query                       |
+| `apps/docs/lib/vector/search.ts`       | runtime retrieval                       | 고정 locale namespace, 기본 topK 5, minScore 0.5                  |
+| `apps/docs/lib/ai/rag.ts`              | prompt context                          | 최대 4,000자 context, locale prompt, UNKNOWN 규칙                 |
+| `apps/docs/app/api/chat/route.ts`      | Chat HTTP API                           | 입력/locale 검증, rate limit, retrieval, streaming, typed failure |
+| `apps/docs/README.md`                  | 운영 경계                               | `ai`가 외부 상태 변경 명령임을 명시                               |
+
+보존할 강점:
+
+- canonical 화면 문서와 RAG 입력은 계속 하나의 source를 사용한다.
+- KO/EN index와 retrieval은 locale 경계를 유지한다.
+- Chat 실패는 문서 읽기와 탐색을 막지 않는다.
+- rate limit, server failure와 network failure의 typed recovery 계약을 보존한다.
+- 외부 AI 요청 없이 Chat presentation/error state를 재현할 수 있다.
+
+## 목표
+
+1. 새 index build가 실패해도 기존 활성 index와 사용자 retrieval 결과가 유지된다.
+2. 같은 canonical 입력과 index contract는 같은 content revision과 namespace 후보를 만든다.
+3. 성공한 run만 validation 뒤 활성화되며 migration 중에는 legacy namespace fallback을 제공한다.
+4. 운영자가 locale별 active revision, stale 여부, 최신 run과 실패 원인을 읽기 전용으로 확인한다.
+5. 개발자가 LLM 생성 전 retrieval rank, score, source, section과 context truncation을 재현한다.
+6. KO/EN 고정 질문으로 Hit@3와 MRR을 반복 측정하고 miss를 숨기지 않는다.
+7. 운영 mutation, 관찰 API와 사용자 Chat의 authority를 분리한다.
+
+## 범위
+
+### P0
+
+- deterministic content revision과 versioned namespace plan
+- locale별 `IndexRun` manifest와 상태 전이
+- staging upsert, validation과 active pointer 전환
+- 실패 시 기존 active pointer 보존
+- pointer 부재 시 legacy `ko`, `en` fallback
+- locale별 status read API
+- retrieval inspector read API와 최소 운영 화면
+- KO/EN 합계 12개 이상의 고정 retrieval case와 Hit@3/MRR artifact
+- state, failure, pointer, API, existing Chat recovery와 ops fixture 검증
+- index lifecycle 운영 문서
+
+### P1
+
+- 이전 성공 run으로 명시적 rollback하는 CLI
+- 최근 run history
+- Chat citation link
+- model/version을 포함한 embedding cache key와 선택적 reuse
+- retrieval/indexing latency 관찰값
+- 수동 namespace retention/cleanup 절차
+
+## 제외
+
+- 외부 사용자 문서 업로드/삭제와 CMS
+- 공개 reindex, activate, rollback 또는 namespace delete API
+- 신규 로그인, session, RBAC, authorization와 감사 시스템
+- vector/embedding provider 교체 또는 다중 provider abstraction
+- queue, background worker와 분산 indexing
+- agent orchestration과 tool calling
+- LLM-as-judge 기반 답변 정확도 자동 판정
+- FirstTx package 본체와 Playground 기능 변경
+- 사용자 수, 비용 절감, 대규모 트래픽 또는 답변 정확도 claim
+
+## 핵심 결정
+
+### Canonical source
+
+`content/docs/*.{ko,en}.mdx`를 화면과 RAG의 유일한 content source로 유지한다. 별도 corpus나 upload database를 만들지 않는다.
+
+### 실패 안전 index 전환
+
+활성 namespace를 reset하지 않는다. 새 versioned namespace를 staging으로 만들고 source 수, expected/indexed chunk 수, metadata shape와 locale retrieval smoke를 검증한 뒤 active pointer만 전환한다.
+
+다음 invariant는 P0 전체에서 바뀌지 않는다.
+
+- canonical read, chunk, embedding, upsert 또는 validation 실패는 active pointer를 바꾸지 않는다.
+- 한 locale의 실패는 다른 locale의 active pointer를 바꾸지 않는다.
+- `failed` run은 `active`가 될 수 없다.
+- 새 staging namespace는 activation 전 사용자 retrieval에 노출되지 않는다.
+- pointer가 없는 migration 상태에서만 legacy `ko`, `en` namespace를 읽는다.
+- pointer와 manifest가 불일치하면 임의의 staging namespace를 선택하지 않는다.
+
+### Authority 분리
+
+- CLI: plan, index, evaluate와 P1 rollback
+- 웹 API/UI: status와 retrieval observation만 제공
+- Chat: active pointer가 선택한 namespace의 retrieval consumer
+- 자동 cleanup: P0에서 수행하지 않음
+
+인증 없는 공개 mutation surface는 만들지 않는다.
+
+### 평가 경계
+
+P0는 generation answer accuracy를 자동 판정하지 않는다. 고정 query와 expected source/section을 사용해 retrieval Hit@3와 MRR을 계산한다. prompt는 known context, empty retrieval과 UNKNOWN 규칙을 unit test로 검증하고, Chat recovery E2E는 유지한다.
+
+## 목표 도메인 모델
+
+### `IndexRun`
+
+```ts
+type IndexRunState = 'prepared' | 'indexing' | 'validating' | 'active' | 'failed';
+
+interface IndexRun {
+  id: string;
+  locale: 'ko' | 'en';
+  state: IndexRunState;
+  namespace: string;
+  contentRevision: string;
+  indexContractVersion: string;
+  embeddingModel: string;
+  startedAt: string;
+  finishedAt?: string;
+  sourceCount: number;
+  expectedChunkCount: number;
+  indexedChunkCount: number;
+  previousActiveRunId?: string;
+  failureCause?:
+    'embedding_failed' | 'vector_upsert_failed' | 'validation_failed' | 'activation_failed';
+}
+```
+
+### `ActiveIndexPointer`
+
+```ts
+interface ActiveIndexPointer {
+  locale: 'ko' | 'en';
+  runId: string;
+  namespace: string;
+  contentRevision: string;
+  activatedAt: string;
+}
+```
+
+### `RetrievalEvaluationCase`
+
+```ts
+interface RetrievalEvaluationCase {
+  id: string;
+  locale: 'ko' | 'en';
+  query: string;
+  expectedSources: string[];
+  expectedSections?: string[];
+}
+```
+
+최종 필드, validation과 저장 형식은 해당 task SPEC에서 확정한다. 공개 API에는 provider payload, token, credential, 내부 URL과 raw embedding을 포함하지 않는다.
+
+## HTTP와 CLI 목표 계약
+
+### Read-only HTTP
+
+- `GET /api/rag/status?locale=ko`
+  - `ready | stale | uninitialized | degraded`
+  - active revision, source/chunk 수, activation 시각과 latest run summary
+- `POST /api/rag/retrievals`
+  - 생성 모델을 호출하지 않는 retrieval query
+  - trim 후 query 1~~500자, locale allowlist, topK 1~~8
+  - runId, rank, score, title, section, canonical href, contextChars, truncated
+  - rate limit과 제한된 public preview
+
+`POST /api/rag/reindex`, `POST /api/rag/activate`, `POST /api/rag/rollback`, `DELETE /api/rag/namespaces/*`는 P0에서 금지한다.
+
+### CLI
+
+```text
+pnpm --filter @firsttx/docs ai:plan
+pnpm --filter @firsttx/docs ai:index
+pnpm --filter @firsttx/docs ai:evaluate
+pnpm --filter @firsttx/docs ai:rollback -- --locale ko --run <runId>
+```
+
+- `ai:plan`: read-only source/chunk/revision/namespace plan
+- `ai:index`: staging build, validation, active pointer 전환
+- `ai:evaluate`: 현재 active index에 고정 retrieval case 실행
+- `ai:rollback`: P1, 이전 성공 run 재활성화
+- 기존 `ai`: P0 전환 완료 뒤 `ai:index` alias로 보존
+
+## 작업 순서
+
+| Task | 목표                          | 주요 산출물                                                      | 선행 조건                                                                     | 완료 gate                                         |
+| ---- | ----------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------- |
+| T1   | deterministic index plan      | pure revision/plan contract, `ai:plan`, unit test, README        | [T1 SPEC](../spec-packets/2026-08-07-deterministic-index-plan.md) 사용자 확정 | T1 AC 전체                                        |
+| T2   | versioned run manifest        | `IndexRun` repository, 상태 전이, staging write                  | pointer 저장소와 retention 결정                                               | 실패 run이 stable cause를 남기고 active 불변      |
+| T3   | validation과 activation       | count/metadata/smoke validation, active pointer, legacy fallback | provider postcondition 확정                                                   | 성공 run만 active, failure 후 기존 retrieval 유지 |
+| T4   | runtime resolution과 status   | active resolver, status API, stale/degraded projection           | T3                                                                            | runtime과 status가 같은 pointer 계약 사용         |
+| T5   | retrieval inspection과 평가   | retrieval API, KO/EN case, Hit@3/MRR runner                      | canonical href와 artifact 위치 결정                                           | 재현 가능한 metric/miss artifact                  |
+| T6   | 최소 ops UI와 failure defense | `/{locale}/ops/rag`, fixture, contract/E2E/build 검증            | T4, T5                                                                        | ops failure가 Docs/Chat을 막지 않음               |
+| T7   | 운영 마감                     | README, operations guide, P1 rollback/cleanup 판단               | P0 evidence                                                                   | 명령, 권한, 실패, metric과 한계가 일치            |
+
+### T1 — deterministic index plan
+
+외부 credential과 provider 요청 없이 canonical MDX에서 locale별 content revision, versioned namespace 후보, source 수와 expected chunk 수를 산출한다. 기존 `ai` mutation 경로는 변경하지 않는다. 세부 계약과 질문은 연결된 SPEC packet이 소유한다.
+
+### T2 — versioned run manifest
+
+`prepared -> indexing -> validating -> active`와 진행 상태의 `failed` 전이를 구현한다. manifest 저장소, key schema, run retention과 failure sanitization을 이 task의 SPEC에서 먼저 확정한다.
+
+### T3 — validation과 activation
+
+expected/indexed chunk 수뿐 아니라 metadata shape와 locale retrieval smoke를 통과한 run만 active pointer로 전환한다. activation 실패 뒤 pointer를 다시 읽어 확인된 기존 active만 사용한다.
+
+### T4 — runtime resolution과 status
+
+runtime search를 active pointer resolver에 연결하고 migration 중 pointer가 없을 때만 legacy namespace로 fallback한다. current build revision과 active revision을 비교해 status를 projection한다.
+
+### T5 — retrieval inspection과 평가
+
+LLM generation을 호출하지 않는 retrieval API와 고정 case runner를 만든다. initial universe는 KO 6건, EN 6건이며 Prepaint, Local-First, Tx의 증상/계약 질문을 포함한다.
+
+### T6 — 최소 ops UI와 failure defense
+
+화려한 dashboard가 아니라 active summary, latest run, retrieval table, evaluation summary와 mutation boundary만 제공한다. loading, stale, uninitialized, degraded, retrieval-empty/error fixture를 외부 provider 없이 재현한다.
+
+### T7 — 운영 마감
+
+운영 문서가 실제 명령, 실패 처리, 외부 상태 변경 승인과 검증 artifact를 연결한다. P1은 P0 evidence가 모두 닫힌 뒤에만 선택한다.
+
+## 파일 소유 예상
+
+실제 task 시작 전에 같은 책임의 기존 파일과 naming을 다시 대조해 신규 파일 수를 줄인다.
+
+| 경로                                        | 예상 책임                                                     |
+| ------------------------------------------- | ------------------------------------------------------------- |
+| `apps/docs/package.json`                    | `ai:plan`, `ai:index`, `ai:evaluate`, 조건부 rollback scripts |
+| `apps/docs/scripts/main.ts`                 | reset-first orchestration을 lifecycle 단계로 교체             |
+| `apps/docs/scripts/vector.ts`               | versioned namespace mutation과 validation primitive           |
+| `apps/docs/lib/ai/index-contract.ts`        | plan, run, pointer와 evaluation의 공유 계약                   |
+| `apps/docs/lib/ai/index-run.ts`             | manifest 저장/조회와 상태 전이                                |
+| `apps/docs/lib/vector/active-index.ts`      | pointer resolve, activate와 legacy fallback                   |
+| `apps/docs/lib/vector/search.ts`            | active namespace와 search metadata 적용                       |
+| `apps/docs/app/api/rag/status/route.ts`     | status read API                                               |
+| `apps/docs/app/api/rag/retrievals/route.ts` | rate-limited retrieval read API                               |
+| `apps/docs/app/[locale]/ops/rag/page.tsx`   | 최소 ops page                                                 |
+| `apps/docs/components/rag-ops/*`            | status, inspector와 evaluation UI                             |
+| `apps/docs/evaluations/*`                   | KO/EN case와 결과 schema                                      |
+| `apps/docs/scripts/evaluate-retrieval.ts`   | Hit@3와 MRR runner                                            |
+| `apps/docs/README.md`                       | 명령과 mutation boundary                                      |
+| `docs/operations/rag-index-operations.md`   | lifecycle, failure와 운영 절차                                |
+
+## 전체 Acceptance Criteria
+
+- AC1: canonical MDX에서 prompt context까지 producer-consumer 경로가 코드와 문서에서 추적된다.
+- AC2: 같은 canonical 입력과 index contract가 같은 locale별 revision과 namespace plan을 만든다.
+- AC3: index build는 active namespace를 먼저 reset하지 않는다.
+- AC4: embedding, upsert 또는 validation 실패 뒤 active pointer와 사용자 retrieval 결과가 유지된다.
+- AC5: 성공한 run만 active pointer로 전환된다.
+- AC6: runtime search는 active pointer를 사용하고 migration 중 legacy fallback을 제공한다.
+- AC7: status API는 ready, stale, uninitialized, degraded를 구분하고 secret/provider payload를 노출하지 않는다.
+- AC8: retrieval API는 query, locale, topK를 검증하고 rate limit과 public source metadata를 제공한다.
+- AC9: ops 화면은 active/latest run, retrieval 결과와 평가 요약을 표시하며 Docs/Chat과 독립적으로 실패한다.
+- AC10: KO/EN 합계 12개 이상의 고정 case에 Hit@3와 MRR artifact가 존재한다.
+- AC11: Hit@3가 0.80 미만이면 miss와 보류 결정을 결과에 남긴다.
+- AC12: state, pointer, API, existing Chat recovery, ops fixture test와 docs typecheck/lint/build가 통과한다.
+- AC13: 공개 mutation endpoint와 신규 auth/RBAC를 추가하지 않는다.
+- AC14: README와 operations guide가 기존 위험, 권한 경계, 명령, 결과와 남은 한계를 설명한다.
+
+## Verification strategy
+
+### 외부 상태를 바꾸지 않는 검증
+
+```bash
+asdf current nodejs
+command -v node
+command -v pnpm
+corepack --version
+pnpm --pm-on-fail=error --version
+pnpm --filter @firsttx/docs typecheck
+pnpm --filter @firsttx/docs lint
+pnpm --filter @firsttx/docs test:run
+pnpm --filter @firsttx/docs build
+pnpm --filter @firsttx/docs test:e2e
+pnpm --filter @firsttx/docs ai:plan
+```
+
+### 외부 상태를 읽거나 바꾸는 검증
+
+provider credential을 사용하는 query/evaluation과 Redis/Vector mutation은 별도 승인을 받은 뒤 실행한다.
+
+```bash
+pnpm --filter @firsttx/docs ai:index
+pnpm --filter @firsttx/docs ai:evaluate
+```
+
+실행 전후 active pointer, 새 run manifest, 기존 namespace 보존, Chat smoke, status/ops와 evaluation artifact를 함께 기록한다. `ai:index` 실패 뒤 active pointer가 유지되지 않으면 P0 전체는 실패다.
+
+## Open decision gates
+
+| Gate                                                 | 닫아야 하는 시점 | 기본 방향                                                        | 미확정 영향                             |
+| ---------------------------------------------------- | ---------------- | ---------------------------------------------------------------- | --------------------------------------- |
+| Upstash activation postcondition과 pointer atomicity | T2 시작 전       | Redis pointer를 단일 locale key로 관리하고 전환 후 재조회        | manifest/pointer 저장 계약              |
+| current build revision의 runtime 제공 방식           | T4 시작 전       | build artifact를 읽음                                            | stale projection과 deploy contract      |
+| canonical href helper                                | T5 시작 전       | 기존 locale route/anchor owner 재사용                            | retrieval response 계약                 |
+| evaluation result 위치                               | T5 시작 전       | case는 repo, raw result는 timestamped artifact, 문서는 최신 요약 | diff 크기와 CI artifact 보존            |
+| ops route production 노출                            | T6 시작 전       | feature flag, read-only, public metadata만 제공                  | route discoverability와 security review |
+| legacy namespace retention                           | T7 시작 전       | 자동 cleanup 없음                                                | storage cost와 rollback window          |
+
+## 위험과 범위 축소 순서
+
+| 위험                                   | 대응                                                         |
+| -------------------------------------- | ------------------------------------------------------------ |
+| reset-first 경로와 새 경로가 함께 남음 | 기존 `ai` alias 전환 시점과 제거 gate를 T3에 고정            |
+| provider capability를 추측             | T2 전에 공식 SDK/실환경 read-only probe로 postcondition 확인 |
+| 평가 case를 현재 결과에 과적합         | 사용자 증상/계약 질문과 expected source를 실행 전에 고정     |
+| ops UI가 auth 작업으로 확장            | mutation 금지, 공개 metadata 제한, feature flag 유지         |
+| 기존 Chat recovery 회귀                | Chat route contract와 기존 unit/E2E를 필수 gate로 유지       |
+| 여러 task가 한 diff에 섞임             | task별 SPEC, ownership과 acceptance 단위로 구현/검증         |
+
+일정이 밀리면 최근 run history, rollback CLI, Chat citation, latency, embedding cache 개선 순서로 제외한다. 다음은 끝까지 유지한다.
+
+1. failed index가 active를 바꾸지 않는 invariant
+2. active revision/status 조회
+3. retrieval inspector
+4. 고정 질문 평가와 miss artifact
+5. 운영 문서와 회귀 테스트
+
+## 현재 진행 상태
+
+- [x] 전체 engineering plan을 FirstTx 저장소에 정규화
+- [x] 첫 구현 task의 SPEC packet 작성
+- [ ] T1 packet의 미정 질문 사용자 확정
+- [ ] T1 구현 시작 신호
+- [ ] T1~T7 구현과 검증
+
+이 문서 작성 시점에는 production/test code, package script와 외부 provider 상태를 변경하지 않았다.

--- a/docs/spec-packets/2026-08-07-deterministic-index-plan.md
+++ b/docs/spec-packets/2026-08-07-deterministic-index-plan.md
@@ -1,0 +1,299 @@
+# T1 — deterministic index plan
+
+- 상태: 질문 필요, 구현 미시작
+- 현재 작업 분류: L-A (계획과 SPEC 문서화)
+- 후속 구현 예상 분류: M-C
+- packet mode: interactive
+- 작성일: 2026-08-07
+- 상위 계획: [FirstTx Docs RAG defense plan](../plans/2026-08-07-rag-defense-plan.md)
+
+## 사용자 확정 신호
+
+2026-08-07 사용자 요청은 전체 계획과 첫 task의 `spec-gated-coding` 문서화까지만 허용한다. production/test code, package script, 외부 provider와 Git 상태 변경은 승인 범위가 아니다. 후속 구현은 사용자가 이 packet의 미정 질문에 답하고 `구현 시작`, `이대로 진행`과 같은 별도 신호를 준 뒤 시작한다.
+
+## 내가 이해한 요청
+
+RAG lifecycle 전체를 한 번에 구현하기 전에, 외부 상태를 전혀 건드리지 않고 현재 canonical MDX가 어떤 index를 만들 예정인지 결정적으로 설명하는 첫 구현 단위를 고정한다.
+
+T1은 locale별 canonical source를 읽고 content revision, versioned namespace 후보, source 수와 expected chunk 수를 JSON으로 산출하는 `ai:plan`을 추가한다. 현재 reset-first `ai` 명령, runtime search와 Chat 동작은 바꾸지 않는다.
+
+## 현재 확정된 것
+
+- `apps/docs/content/docs/*.{ko,en}.mdx`가 화면과 RAG 입력의 유일한 canonical content source다.
+- `readCanonicalMdxDocuments`가 MDX를 정규화하고 source 이름으로 정렬한다.
+- `chunkMarkdown`가 실제 indexing의 chunk 계약을 소유한다.
+- 실제 indexing과 runtime query embedding은 현재 `text-embedding-3-small`을 사용한다.
+- content revision은 normalized content, locale, chunk/index contract version과 embedding model identifier를 안정적으로 직렬화한 SHA-256이다.
+- namespace 후보는 `rag-{locale}-{contentRevision 앞 12자}`다.
+- `ai:plan`은 credential, `.env*`, Redis, Vector와 embedding provider를 읽거나 호출하지 않는다.
+- 기존 `ai` 명령의 이름과 reset-first 실행 순서는 T1에서 유지한다.
+- 새 dependency를 추가하지 않는다.
+
+## 미정 질문
+
+아래 질문은 future T1 implementation의 load-bearing behavior다.
+
+1. 해당 locale의 canonical 문서가 0개일 때 `ai:plan`이 non-zero exit로 실패해야 하는가, 아니면 count 0의 plan을 출력해야 하는가?
+   - 권장: 실패. 빈 staging namespace를 정상 plan으로 취급하지 않는 편이 이후 activation 경계와 일치한다.
+2. T1의 CLI가 항상 KO/EN plan을 함께 출력해야 하는가, `--locale ko|en` 선택도 처음부터 지원해야 하는가?
+   - 권장: KO/EN을 항상 함께 출력. 첫 task의 CLI surface와 test matrix를 줄이고 locale별 실행은 실제 index task에서 결정한다.
+
+사용자 답변 전에는 권장안을 임시 가정으로만 유지하고 production/test code를 수정하지 않는다.
+
+## 임시 가정
+
+- 빈 locale 입력은 stable error message와 non-zero exit로 거절한다.
+- `ai:plan`은 인자를 받지 않고 KO, EN 순서의 JSON array 하나를 stdout에 출력한다.
+- 사람이 읽는 진행 로그는 출력하지 않는다. JSON consumer가 파싱할 수 있는 stdout 계약을 유지한다.
+- content revision은 chunk 결과 전체를 중복 직렬화하지 않고 normalized document 입력과 명시적 contract version을 hash한다. chunk algorithm 의미가 바뀌면 contract version을 올린다.
+
+## 목표
+
+1. 같은 의미의 canonical 입력은 파일 열거 순서와 무관하게 같은 locale별 plan을 만든다.
+2. content, locale, index contract version 또는 embedding model identifier가 바뀌면 revision도 바뀐다.
+3. plan의 source/chunk 수가 실제 canonical reader와 chunker 결과에 일치한다.
+4. credential이 없는 로컬/CI 환경에서 외부 side effect 없이 plan을 확인한다.
+5. 이후 `IndexRun`과 staging indexer가 공유할 최소 revision/namespace 계약을 제공한다.
+
+## 범위
+
+- embedding model identifier의 단일 상수 owner
+- index contract version 상수
+- locale별 canonical document selection과 안정 정렬
+- SHA-256 content revision 계산
+- versioned namespace 후보 생성
+- source count와 expected chunk count 계산
+- 순수 `IndexPlan` 생성 함수
+- KO/EN JSON을 출력하는 `ai:plan` package script
+- 결정성, revision sensitivity, count와 no-credential 실행 test
+- `apps/docs/README.md`에 read-only/mutation 명령 경계 추가
+
+## 제외
+
+- embedding 생성과 vector upsert
+- `IndexRun` 저장소와 상태 전이
+- active pointer 생성/전환/rollback
+- 현재 `ai` 명령의 alias 또는 동작 변경
+- runtime search namespace 변경
+- status/retrieval API와 ops UI
+- evaluation case와 Hit@3/MRR runner
+- embedding cache key 변경
+- provider credential 검증
+- `.env*` 파일 접근
+
+## 도메인 계약
+
+### `IndexPlan`
+
+```ts
+interface IndexPlan {
+  locale: 'ko' | 'en';
+  contentRevision: string;
+  namespace: string;
+  sourceCount: number;
+  expectedChunkCount: number;
+  indexContractVersion: string;
+  embeddingModel: string;
+}
+```
+
+### Revision input
+
+revision 입력은 아래 필드를 이 순서로 가진 JSON object다.
+
+```ts
+interface IndexRevisionInput {
+  locale: 'ko' | 'en';
+  indexContractVersion: string;
+  embeddingModel: string;
+  documents: Array<{
+    docId: string;
+    source: string;
+    content: string;
+  }>;
+}
+```
+
+규칙:
+
+1. 입력 documents에서 plan locale과 같은 문서만 선택한다.
+2. 선택한 문서를 `source` 오름차순으로 정렬한다.
+3. `content`는 `normalizeCanonicalMdx` 결과를 그대로 사용한다.
+4. 위 object를 `JSON.stringify`한 UTF-8 byte의 SHA-256 lowercase hex를 `contentRevision`으로 사용한다.
+5. revision은 64자이며 namespace에는 앞 12자만 사용한다.
+6. source 이름이나 content가 바뀌면 revision도 바뀐다.
+7. chunk 수는 선택한 각 문서에 현재 `chunkMarkdown`을 적용한 결과의 합이다.
+
+### Contract ownership
+
+- `INDEX_CONTRACT_VERSION`은 revision serialization, normalization 또는 chunk 의미가 바뀔 때 명시적으로 갱신한다.
+- `EMBEDDING_MODEL_ID`는 indexing과 runtime query embedding이 함께 참조할 단일 상수다.
+- plan 함수는 provider client, environment loader, cache와 vector module을 import하지 않는다.
+- `IndexPlan`은 계획 정보이며 activation 권한을 갖지 않는다. count 0을 허용하더라도 후속 validation의 활성화 허가로 해석하지 않는다.
+
+## CLI 계약
+
+명령:
+
+```bash
+pnpm --filter @firsttx/docs ai:plan
+```
+
+성공 stdout:
+
+```json
+[
+  {
+    "locale": "ko",
+    "contentRevision": "<64 lowercase hex>",
+    "namespace": "rag-ko-<revision12>",
+    "sourceCount": 9,
+    "expectedChunkCount": 0,
+    "indexContractVersion": "rag-index-v1",
+    "embeddingModel": "text-embedding-3-small"
+  },
+  {
+    "locale": "en",
+    "contentRevision": "<64 lowercase hex>",
+    "namespace": "rag-en-<revision12>",
+    "sourceCount": 9,
+    "expectedChunkCount": 0,
+    "indexContractVersion": "rag-index-v1",
+    "embeddingModel": "text-embedding-3-small"
+  }
+]
+```
+
+예시의 `expectedChunkCount`는 schema 자리표시자이며 실제 값은 current chunker 결과를 출력한다. 성공 시 stdout에는 JSON 이외의 로그를 섞지 않는다. 실패 시 원인은 stderr로 보내고 non-zero exit를 반환한다.
+
+## 확정 결정
+
+- source reader와 chunker를 복제하지 않고 현재 구현을 재사용한다.
+- locale별 revision을 계산한다.
+- namespace에는 full revision이 아니라 앞 12자를 사용하고 full revision은 plan에 보존한다.
+- timestamp, run ID, 현재 Git revision과 provider state는 content revision에 포함하지 않는다.
+- planner는 synchronous canonical reader/chunker 경계에 맞춰 순수 synchronous 함수로 시작한다.
+- `ai:plan` 자체는 `.env*` loader를 import하지 않는다.
+- 기존 `ai` 명령은 T1에서 건드리지 않는다.
+
+## 검토한 대안
+
+| 대안                                         | 판정 | 이유                                                                               |
+| -------------------------------------------- | ---- | ---------------------------------------------------------------------------------- |
+| timestamp 기반 namespace                     | 거절 | 같은 content의 재현성과 idempotent plan을 잃는다.                                  |
+| chunk payload 전체를 revision에 포함         | 거절 | normalized source와 contract version이 이미 의미를 소유하며 payload 중복이 커진다. |
+| provider에서 현재 namespace를 읽어 plan 생성 | 거절 | read-only local command가 credential과 외부 가용성에 의존한다.                     |
+| 기존 `ai`에 `--dry-run` 추가                 | 거절 | environment/provider import graph와 mutation orchestration에 결합된다.             |
+| model ID literal을 planner에 복제            | 거절 | indexing/query model과 revision model이 조용히 drift할 수 있다.                    |
+
+## 제약
+
+- Node.js 24와 repository `packageManager`의 pnpm 11.17.0을 사용한다.
+- 새 dependency를 설치하지 않는다. SHA-256은 `node:crypto`를 사용한다.
+- `.env`, `.env.local`, `.env.*`를 읽거나 수정하지 않는다.
+- package/test 명령은 `apps/docs` ownership boundary로 제한한다.
+- source code에 주석을 추가하지 않는다.
+- 기존 dirty work가 생기면 unrelated 변경을 보존하고 scope를 다시 분류한다.
+
+## 금지 리팩터
+
+- `canonical-mdx.ts` normalization 의미 변경
+- `chunk-md.ts` chunk boundary/size 변경
+- `main.ts` reset/upsert 순서 변경
+- Redis, Vector와 OpenAI client 구조 변경
+- Chat route, prompt, streaming과 UI 변경
+- route/locale navigation과 Playground 변경
+- 관련 없는 package script 정리
+
+## Acceptance Criteria
+
+- AC-T1: `createIndexPlan(documents, locale)`와 동등한 순수 계약이 `IndexPlan`을 반환한다.
+- AC-T2: 같은 문서 집합의 입력 순서가 바뀌어도 plan 전체가 동일하다.
+- AC-T3: `contentRevision`은 64자 lowercase SHA-256이다.
+- AC-T4: content, locale, index contract version, embedding model 중 하나가 바뀌면 revision이 바뀐다.
+- AC-T5: namespace는 `rag-{locale}-{revision 앞 12자}`다.
+- AC-T6: sourceCount와 expectedChunkCount가 해당 locale의 실제 reader/chunker 결과와 일치한다.
+- AC-T7: 실제 indexing과 runtime query embedding이 plan과 같은 model identifier를 사용한다.
+- AC-T8: credential을 제거한 환경에서 `ai:plan`이 KO/EN JSON을 출력하고 network/provider state를 변경하지 않는다.
+- AC-T9: 기존 `ai` package script와 reset-first orchestration diff가 없다.
+- AC-T10: README가 `ai:plan` read-only와 기존 `ai` mutation 경계를 구분한다.
+- AC-T11: 관련 unit test, docs typecheck, lint와 전체 unit test가 통과한다.
+
+AC-T8의 빈 locale 성공/실패 기대값은 미정 질문 1의 답에 따라 구현 전에 추가한다. AC-T8의 locale 선택 입력은 미정 질문 2의 답에 따라 갱신한다.
+
+## Edge cases
+
+- documents 입력 순서가 뒤집힌다.
+- KO/EN 문서가 같은 배열에 섞여 있다.
+- source가 같고 content만 바뀐다.
+- content가 같고 source만 바뀐다.
+- model 또는 contract version만 바뀐다.
+- 해당 locale 문서가 0개다.
+- canonical reader가 파일을 읽지 못한다.
+- stdout을 JSON parser가 직접 소비한다.
+
+## 구현 Task breakdown
+
+| 순서 | 작업                                                      | 소유 예상                                     | 완료 조건                                         |
+| ---- | --------------------------------------------------------- | --------------------------------------------- | ------------------------------------------------- |
+| 1    | model/index contract 상수와 `IndexPlan` type 배치         | `apps/docs/lib/ai` 또는 가까운 기존 owner     | model literal duplication 제거, import cycle 없음 |
+| 2    | locale selection, stable serialization, hash와 count 함수 | `apps/docs/scripts` 또는 공유 contract owner  | AC-T1~T7 unit test                                |
+| 3    | read-only CLI entry와 package script                      | `apps/docs/scripts`, `apps/docs/package.json` | AC-T8~T9                                          |
+| 4    | README 명령 경계                                          | `apps/docs/README.md`                         | AC-T10                                            |
+| 5    | native verification과 evidence 기록                       | 이 packet Closure                             | AC-T11과 verification claim coverage              |
+
+실제 naming과 file placement는 구현 시작 시 가까운 import convention을 다시 확인해 좁힐 수 있다. Domain contract와 Acceptance가 같으면 implementation change로 기록하고, authority나 CLI behavior가 바뀌면 먼저 이 packet을 reconcile한다.
+
+## Verification map
+
+| Claim                                                        | Type              | 연결 AC    | Planned evidence                                               | Safety        | 현재 coverage |
+| ------------------------------------------------------------ | ----------------- | ---------- | -------------------------------------------------------------- | ------------- | ------------- |
+| C1 revision/namespace가 결정적이고 입력 변화에 민감함        | executable        | AC-T1~T5   | pure unit test                                                 | safe-no-write | uncovered     |
+| C2 source/chunk 수와 model contract가 실제 producer와 일치함 | executable/static | AC-T6~T7   | canonical fixture unit test, call-site diff review             | safe-no-write | uncovered     |
+| C3 `ai:plan`이 JSON-only이고 외부 side effect가 없음         | executable        | AC-T8~T9   | credential-unset CLI, import graph와 existing `ai` diff review | safe-no-write | uncovered     |
+| C4 문서와 native checks가 T1 경계를 보존함                   | static/executable | AC-T10~T11 | README inspection, docs typecheck/lint/full unit test          | safe-no-write | uncovered     |
+
+## 계획 검증 명령
+
+구현 뒤에만 실행한다.
+
+```bash
+asdf current nodejs
+command -v node
+command -v pnpm
+corepack --version
+pnpm --pm-on-fail=error --version
+pnpm --filter @firsttx/docs test:run
+pnpm --filter @firsttx/docs typecheck
+pnpm --filter @firsttx/docs lint
+```
+
+credential을 제거한 `ai:plan` 실행은 `tsx` IPC sandbox 제약이 있으면 동일한 read-only command를 승인된 외부 실행으로 재시도한다. 기존 `ai`는 외부 mutation 명령이므로 T1 verification에서 실행하지 않는다.
+
+## Evidence / Gap log
+
+| 날짜       | 종류     | 내용                                                                                                                             |
+| ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-07 | evidence | canonical reader는 source 정렬과 KO/EN document selection에 필요한 `docId`, `locale`, `source`, normalized `content`를 제공한다. |
+| 2026-08-07 | evidence | current chunker와 indexing script는 같은 locale/docId/source/content 계약을 사용한다.                                            |
+| 2026-08-07 | evidence | indexing과 runtime query embedding은 같은 model ID를 사용하지만 현재 literal owner가 두 곳이다.                                  |
+| 2026-08-07 | evidence | 기존 `ai` 명령은 cache 삭제와 active locale namespace reset을 수행하므로 T1에서 실행하지 않는다.                                 |
+| 2026-08-07 | gap      | 빈 locale과 CLI locale selection behavior는 사용자 결정이 필요하다.                                                              |
+
+## Closure
+
+- 현재 verdict: OPEN — documentation only
+- implementation: NOT_STARTED
+- verification evidence: NOT_RUN
+- change risk: future implementation normal, 전체 lifecycle high
+- evidence confidence: unavailable until implementation
+- state drift: N/A
+- native review: N/A
+- 다음 gate: 미정 질문 2개 답변과 구현 시작 신호
+
+## Reconciliation log
+
+| 날짜       | 변경                                             | 이유                                        | 영향                              |
+| ---------- | ------------------------------------------------ | ------------------------------------------- | --------------------------------- |
+| 2026-08-07 | T1을 전체 lifecycle 문서에서 분리                | 전체 plan과 첫 구현 계약의 ownership을 구분 | T1 구현은 이 packet만 gate로 사용 |
+| 2026-08-07 | 구현을 시작하지 않는 interactive packet으로 고정 | 사용자 요청이 문서화까지만 허용             | production/test/package 변경 없음 |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2867,11 +2867,11 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3838,12 +3838,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5190,8 +5190,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -5731,7 +5731,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -6076,7 +6076,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7500,12 +7500,12 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8718,12 +8718,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -8744,7 +8744,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -9366,11 +9366,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -9760,7 +9760,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -10451,7 +10451,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## What

- Add a repository-owned RAG defense plan covering index lifecycle, active pointers, observability, retrieval evaluation, and rollout tasks.
- Add a gated SPEC packet for the first implementation task: deterministic index planning.
- Record unresolved decisions and require explicit approval before implementation.

## Why

- Convert the external planning artifact into a durable FirstTx engineering contract.
- Separate the overall roadmap from the first task's implementation contract.
- Prevent production changes before scope, acceptance criteria, and CLI behavior are confirmed.

## Testing

- `node_modules/.bin/prettier --check docs/plans/2026-08-07-rag-defense-plan.md docs/spec-packets/2026-08-07-deterministic-index-plan.md` — passed
- Cross-document link and path checks — passed
- Code tests were not run because this is a documentation-only change.

---

**Breaking?** No