### PR TITLE
docs(rag): align defense plan with build artifact reality

### DIFF
--- a/docs/plans/2026-08-07-rag-defense-plan.md
+++ b/docs/plans/2026-08-07-rag-defense-plan.md
@@ -36,20 +36,28 @@ IndexRun + ActiveIndexPointer
   -> fixed-case evaluation
 ```
 
-## 현재 기준선
+## 착수 시점 기준선 (2026-08-07)
 
-| 경로                                     | 현재 책임                               | 기준선                                                                    |
+이 표는 계획을 세운 시점의 상태이며 현재 코드가 아니다. 아래 「폐기된 항목」이 이후 변경을 요약한다.
+
+| 경로                                     | 착수 시점 책임                          | 기준선                                                                    |
 | ---------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------- |
 | `apps/docs/content/docs/*.{ko,en}.mdx`   | 화면과 RAG가 공유하는 canonical content | 9개 document id의 KO/EN pair 18개                                         |
 | `apps/docs/scripts/canonical-mdx.ts`     | MDX normalization                       | 화면 전용 metadata와 JSX를 검색 가능한 Markdown으로 변환                  |
 | `apps/docs/scripts/chunk-md.ts`          | chunking                                | H1/H2/H3 경계, 최소 100자, 최대 2,000자                                   |
-| `apps/docs/scripts/main.ts`              | indexing orchestration                  | cache 삭제 후 locale별 reset, embedding, upsert                           |
-| `apps/docs/scripts/vector.ts`            | vector mutation                         | locale namespace reset, batch upsert, query                               |
+| `apps/docs/scripts/main.ts` (삭제됨)     | indexing orchestration                  | cache 삭제 후 locale별 reset, embedding, upsert                           |
+| `apps/docs/scripts/vector.ts` (삭제됨)   | vector mutation                         | locale namespace reset, batch upsert, query                               |
 | `apps/docs/lib/vector/search.ts`         | runtime retrieval                       | 고정 locale namespace, 함수 기본 topK 5(Chat 실호출 topK 8), minScore 0.5 |
 | `apps/docs/lib/cache/embedding-cache.ts` | runtime query embedding cache           | `emb:` prefix, model 미포함 text hash key, TTL 7일                        |
 | `apps/docs/lib/ai/rag.ts`                | prompt context                          | 최대 4,000자 context, locale prompt, UNKNOWN 규칙                         |
 | `apps/docs/app/api/chat/route.ts`        | Chat HTTP API                           | 입력/locale 검증, rate limit, retrieval, streaming, typed failure         |
 | `apps/docs/README.md`                    | 운영 경계                               | `ai`가 외부 상태 변경 명령임을 명시                                       |
+
+### 폐기된 항목
+
+- `scripts/main.ts`·`scripts/vector.ts`와 `ai` 명령은 T2′에서 삭제됐다. 인덱스는 `scripts/build-index.ts`가 만드는 커밋된 artifact이고 runtime 검색은 `lib/vector/search.ts`의 brute-force cosine이다.
+- `emb:` prefix는 model을 포함하도록 바뀌어 모델 교체 시 옛 embedding이 재사용되지 않는다.
+- Chat route는 rate limiter 장애 시 typed 503으로 fail-closed한다.
 
 보존할 강점:
 
@@ -227,16 +235,19 @@ interface RetrievalEvaluationCase {
 
 ```text
 pnpm --filter @firsttx/docs ai:plan
-pnpm --filter @firsttx/docs ai:index
+pnpm --filter @firsttx/docs ai:build-index
+pnpm --filter @firsttx/docs ai:check-index
 pnpm --filter @firsttx/docs ai:evaluate
-pnpm --filter @firsttx/docs ai:rollback -- --locale ko --run <runId>
+pnpm --filter @firsttx/docs ai:probe-unknown
 ```
 
-- `ai:plan`: read-only source/chunk/revision/namespace plan
-- `ai:index`: staging build, validation, active pointer 전환
-- `ai:evaluate`: 현재 active index에 고정 retrieval case 실행
-- `ai:rollback`: P1, 이전 성공 run 재활성화
-- 기존 `ai`: T3에서 `ai:index` alias로 전환하고 제거 gate를 함께 고정
+- `ai:plan`: read-only source/chunk/revision plan
+- `ai:build-index`: canonical MDX를 재임베딩해 커밋 대상 artifact를 재생성
+- `ai:check-index`: artifact revision과 canonical 문서 일치 검사. CI가 매 PR에서 실행
+- `ai:evaluate`: 고정 retrieval case로 Hit@3/MRR과 keyword baseline 측정
+- `ai:probe-unknown`: 문서에 답이 없는 질문에서 UNKNOWN 규칙 준수 확인 (생성 호출 발생)
+
+`ai:index`와 `ai:rollback`은 T2/T3 폐기와 함께 만들어지지 않았다. artifact를 되돌리는 것이 곧 rollback이다.
 
 ## 작업 순서
 
@@ -284,23 +295,22 @@ LLM generation을 호출하지 않는 retrieval API와 고정 case runner를 만
 
 실제 task 시작 전에 같은 책임의 기존 파일과 naming을 다시 대조해 신규 파일 수를 줄인다.
 
-| 경로                                        | 예상 책임                                                     |
-| ------------------------------------------- | ------------------------------------------------------------- |
-| `apps/docs/package.json`                    | `ai:plan`, `ai:index`, `ai:evaluate`, 조건부 rollback scripts |
-| `apps/docs/scripts/main.ts`                 | reset-first orchestration을 lifecycle 단계로 교체             |
-| `apps/docs/scripts/vector.ts`               | versioned namespace mutation과 validation primitive           |
-| `apps/docs/lib/ai/index-contract.ts`        | plan, run, pointer와 evaluation의 공유 계약                   |
-| `apps/docs/lib/ai/index-run.ts`             | manifest 저장/조회와 상태 전이                                |
-| `apps/docs/lib/vector/active-index.ts`      | pointer resolve, activate와 legacy fallback                   |
-| `apps/docs/lib/vector/search.ts`            | active namespace와 search metadata 적용                       |
-| `apps/docs/app/api/rag/status/route.ts`     | status read API                                               |
-| `apps/docs/app/api/rag/retrievals/route.ts` | rate-limited retrieval read API                               |
-| `apps/docs/app/[locale]/ops/rag/page.tsx`   | 최소 ops page                                                 |
-| `apps/docs/components/rag-ops/*`            | status, inspector와 evaluation UI                             |
-| `apps/docs/evaluations/*`                   | KO/EN case와 결과 schema                                      |
-| `apps/docs/scripts/evaluate-retrieval.ts`   | Hit@3와 MRR runner                                            |
-| `apps/docs/README.md`                       | 명령과 mutation boundary                                      |
-| `docs/operations/rag-index-operations.md`   | lifecycle, failure와 운영 절차                                |
+| 경로                                         | 예상 책임                                                                        |
+| -------------------------------------------- | -------------------------------------------------------------------------------- |
+| `apps/docs/package.json`                     | `ai:plan`, `ai:build-index`, `ai:check-index`, `ai:evaluate`, `ai:probe-unknown` |
+| `apps/docs/scripts/build-index.ts`           | canonical MDX 재임베딩과 artifact 생성 (구현됨)                                  |
+| `apps/docs/scripts/check-index-freshness.ts` | artifact와 문서 revision 대조 (구현됨)                                           |
+| `apps/docs/lib/vector/artifact-contract.ts`  | packed artifact 형식과 cosine 계약 (구현됨)                                      |
+| `apps/docs/lib/ai/index-contract.ts`         | plan과 evaluation의 공유 계약 (구현됨)                                           |
+| `apps/docs/lib/vector/search.ts`             | artifact brute-force 검색 (구현됨)                                               |
+| `apps/docs/app/api/rag/status/route.ts`      | status read API (T4′, 미착수)                                                    |
+| `apps/docs/app/api/rag/retrievals/route.ts`  | rate-limited retrieval read API (T5b, 미착수)                                    |
+| `apps/docs/app/[locale]/ops/rag/page.tsx`    | 최소 ops page (T6, 미착수)                                                       |
+| `apps/docs/components/rag-ops/*`             | status, inspector와 evaluation UI (T6, 미착수)                                   |
+| `apps/docs/evaluations/*`                    | KO/EN case와 결과 schema (구현됨)                                                |
+| `apps/docs/scripts/evaluate-retrieval.ts`    | Hit@3와 MRR runner (구현됨)                                                      |
+| `apps/docs/README.md`                        | 명령과 mutation boundary (구현됨)                                                |
+| `docs/operations/rag-index-operations.md`    | lifecycle, failure와 운영 절차 (T7, 미착수)                                      |
 
 ## 전체 Acceptance Criteria
 
@@ -338,14 +348,15 @@ pnpm --filter @firsttx/docs ai:plan
 
 ### 외부 상태를 읽거나 바꾸는 검증
 
-provider credential을 사용하는 query/evaluation과 Redis/Vector mutation은 별도 승인을 받은 뒤 실행한다.
+provider credential을 사용하는 embedding·generation 호출은 별도 승인을 받은 뒤 실행한다. 외부 저장소 상태를 바꾸는 명령은 더 이상 없다.
 
 ```bash
-pnpm --filter @firsttx/docs ai:index
+pnpm --filter @firsttx/docs ai:build-index
 pnpm --filter @firsttx/docs ai:evaluate
+pnpm --filter @firsttx/docs ai:probe-unknown
 ```
 
-실행 전후 active pointer, 새 run manifest, 기존 namespace 보존, Chat smoke, status/ops와 evaluation artifact를 함께 기록한다. `ai:index` 실패 뒤 active pointer가 유지되지 않으면 P0 전체는 실패다.
+`ai:build-index`는 저장소 파일만 바꾸므로 되돌리기는 그 파일을 되돌리는 것으로 끝난다. 실행 뒤 `ai:check-index` 통과와 evaluation artifact를 함께 기록한다.
 
 ## Open decision gates
 
@@ -397,12 +408,10 @@ pnpm --filter @firsttx/docs ai:evaluate
 - [x] Chat 재활성화 **코드 준비** — rate limiter 장애 시 typed 503 fail-closed로 교정, route 회귀 테스트 4건 추가
 - [x] Chat 재활성화 **로컬 검증** — Redis 재생성 확인(remaining 9→8), Chat 위젯·전체 대화 경로·UNKNOWN 규칙 end-to-end 통과
 - [ ] Chat 재활성화 **프로덕션** — Vercel 환경변수 4종 설정 (사용자 작업)
-- [ ] T2~~T4, T5b, T6~~T7 구현과 검증
+- [ ] T4′ 최소 status, T5b retrieval API, T6 ops UI, T7 운영 문서 — 판단 대기
 
 2026-08-08 chat model을 `gpt-4o-mini`에서 `gpt-5.6-luna`로 올렸다. embedding model은 `text-embedding-3-small`이 여전히 OpenAI 최신이라 유지했고, 따라서 index와 측정된 Hit@3는 영향을 받지 않는다. Luna는 reasoning model이라 `temperature`를 지원하지 않아 chat route의 `temperature: 0.1`을 제거했다. 실측 usage에서 `reasoningTokens`는 0이었다.
 
 2026-08-08 기준 Upstash Vector와 Redis 무료 티어 DB는 미사용으로 삭제된 상태다. 프로덕션 `firsttx.store`는 정상이며 Chat이 노출되지 않아 사용자 영향은 없다. 이 계획이 방어하려는 **기존 활성 index가 현재 존재하지 않으므로**, 구조 변경 비용이 가장 낮은 시점이다.
 
-T1은 `ai:plan` read-only 경로와 공유 index contract를 추가했고 기존 `ai` mutation orchestration은 diff 없이 보존했다. 외부 provider 상태는 아직 변경하지 않았다.
-
-T2 착수 전에 `Open decision gates`의 Upstash activation postcondition과 pointer atomicity를 read-only probe로 닫는다.
+`Open decision gates`의 Upstash activation postcondition, pointer atomicity, legacy namespace retention은 T2/T3 폐기와 함께 닫혔다. 외부 vector 저장소가 없으므로 판정할 대상이 없다.

--- a/docs/spec-packets/2026-07-16-docs-uiux-redesign.md
+++ b/docs/spec-packets/2026-07-16-docs-uiux-redesign.md
@@ -1,0 +1,156 @@
+---
+workflow_version: 2
+status: awaiting-approval
+target: 'apps/docs 전체 (랜딩 + docs 셸 + 공통 셸 + MDX 렌더링 컴포넌트)'
+mode: redesign
+anchor: 'Company anchor: Linear'
+baseline: 'artifacts/uiux/docs-uiux-redesign/baseline/ (7장, 2026-07-16, main@c2280ba + untracked docs/spec-packets)'
+acceptance_source: '이 packet (기존 product SPEC 없음)'
+candidate_ids: [A-framed-monolith, B-layer-ladder, C-workspace-shell, D-docs-first-economy]
+implemented_candidate_ids: [A-framed-monolith, B-layer-ladder]
+final_decision_mode: 'synthesize (제안, 승인 대기)'
+approved_direction: ''
+capture_manifest: '이 문서의 Capture Manifest 섹션'
+---
+
+# Production UI Decision Packet — apps/docs UI/UX 전면 재작성
+
+## Target와 사용자 Job
+
+- Target route/component: `apps/docs` 전체 — `app/[locale]/page.tsx`(랜딩), `app/[locale]/docs/**`(문서 6페이지), 공통 셸(navbar/footer/sidebar), MDX 컴포넌트(code-block/api-table/callout/install-tabs).
+- 사용자 job: (1) React 개발자가 FirstTx가 무슨 문제를 푸는지 10초 안에 파악하고 설치 경로로 진입, (2) 문서에서 레이어별 API·개념을 빠르게 탐색.
+- 현재 구조: hero(2col: 텍스트+데모카드) → layers 3카드 → experience 카드+타임라인 → quickstart 탭. 레드/로즈 액센트 남용(헤드라인 전체가 레드), 장식성 글로우·그리드 배경, shadcn 기본 zinc 토큰. docs는 최소한의 사이드바+본문.
+
+## Invariant와 Non-goal
+
+- Existing content/function invariant:
+  - `messages/{ko,en}.json`의 모든 콘텐츠(네임스페이스: Hero, DemoCard, HeaderRow, Layers, Experience, Timeline, QuickStart, Footer, DocsNav)를 그대로 사용. 문구 수정 없음.
+  - `content/docs/*.mdx` 본문 무변경. MDX 컴포넌트의 props 계약(Callout type/title, ApiTable kind/items, InstallTabs packages/dev/title, CodeBlock=pre) 유지.
+  - 링크 target 유지: playground URL, GitHub URL, `#quickstart` 앵커, docs 라우트 6개.
+  - ko/en i18n(next-intl) 라우팅·메시지 구조 유지. 다크/라이트 전환(next-themes) 유지, 다크 우선 설계.
+  - JSON-LD, 메타데이터, sitemap/robots 구조 유지.
+- Existing data/handler/routing/i18n/a11y/state invariant:
+  - 패키지 매니저 탭 선택, 코드 copy 버튼, 모바일 메뉴 토글, 테마/로케일 스위처 기능 유지.
+  - 현재 nav는 `<a href>`(하드 리로드)·`next/link`·수동 로케일 프리픽스가 혼재 — 재작성 시 next-intl 인식 내비게이션으로 정리하되 목적지·기능은 동일(사용자 승인된 brief의 "전면 재작성" 범위 내 기술 정리로 간주).
+- Approved additive contract (사용자 사전 승인, 2026-07-16 대화):
+  - 챗봇 기능 전체 제거: `components/chat/`, `app/api/chat/`, `lib/ai|vector|cache|ratelimit/`, `scripts/`(임베딩 파이프라인), `pnpm ai` 스크립트, openai/ai-sdk/upstash 의존성. 결합점은 `app/[locale]/layout.tsx`의 import+렌더 2줄뿐임을 실측 확인.
+  - 브랜드 컬러를 로즈/레드에서 앵커 기반 자체 정의값으로 교체.
+- Non-goal: MDX 본문 수정, 새 문서 페이지 추가, playground 앱 변경, 문서 우측 TOC 신설(TBD로 보류), 검색 기능, SEO 구조 변경.
+
+## Acceptance와 Evidence Trace
+
+- Acceptance source: 이 packet (기존 SPEC 없음).
+- Edge cases: 로케일 스위칭 시 경로 보존, 모바일 사이드바 진입 경로, MDX 긴 코드블록 overflow, reduced-motion, ko 한글 타이포(라틴 전용 네거티브 트래킹 금지).
+- TBD와 owner/decision trigger: docs 우측 TOC 추가 여부(owner: 사용자, final 승인 시 결정), Pretendard 등 한글 웹폰트 도입 여부(owner: 사용자, final 승인 시 결정 — 후보 단계는 시스템 한글 폰트 스택).
+
+| ID  | Actor/trigger/state         | Expected outcome                                                   | Planned/actual evidence                              | Status  |
+| --- | --------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------- | ------- |
+| AC1 | 방문자가 /ko, /en 랜딩 진입 | 기존 i18n 콘텐츠 그대로, 새 IA·비주얼로 렌더                       | final 스크린샷(데스크톱/모바일, ko/en) + 빌드 통과   | pending |
+| AC2 | 방문자가 docs 6페이지 열람  | MDX 본문 무변경, 새 docs 셸·MDX 컴포넌트 스타일                    | final 스크린샷 + `git diff content/docs` 무변경 확인 | pending |
+| AC3 | 다크/라이트 테마 전환       | 두 테마 모두 의도된 완성도(다크 우선)                              | 테마별 스크린샷                                      | pending |
+| AC4 | 챗봇 제거 후 빌드           | typecheck/lint/build 통과, 잔여 import 0                           | 명령 결과 + grep 잔여 확인                           | pending |
+| AC5 | 키보드 사용자 탐색          | focus-visible, 시맨틱 role, 모바일 메뉴 키보드 경로                | 브라우저 캡처/검사                                   | pending |
+| AC6 | 시각 시스템                 | 단일 크로마틱 액센트, 장식성 그라디언트·글로우 제거, hairline 위계 | final 스크린샷 + 코드 확인                           | pending |
+
+## Anchor Decision
+
+- Decision: Company anchor — **Linear** (사용자 선택, 2026-07-16).
+- Evidence/source:
+  - 공식: Linear "How we redesigned the Linear UI" — LCH 색공간, base/accent/contrast 3변수 테마, Inter Display(제목)+Inter(본문), "reduce visual noise, maintain visual alignment, increase hierarchy and density".
+  - 비공식 seed(참고용, 권위 아님): VoltAgent/awesome-design-md의 linear.app DESIGN.md — 단일 크로마틱 액센트(라벤더-블루)를 브랜드·포커스·primary CTA에만, near-black surface ladder, hairline 보더 3단계, display 600/body 400 + 네거티브 트래킹, 4px 스페이싱, pill CTA 금지.
+- Local signal mapping (값 복사가 아닌 번역):
+  - Color: 자체 정의 다크 캔버스 + surface ladder(3~~4단) + hairline 보더 2~~3단 + **단일 크로마틱 액센트**(후보별 자체 oklch 값). 상태색(success/pending/error)은 저채도 시맨틱 토큰으로 한정. 기존 chart-* 그라디언트 남용 제거.
+  - Typography: 기존 Geist(이미 로드됨)를 유지하되 display 계층(600, 네거티브 트래킹)과 body(400) 대비 강화. 한글은 트래킹 완화(-0.01em 이하) + 시스템 한글 폰트 스택 — 라틴 전용 트래킹/폰트를 한글에 그대로 적용하지 않음.
+  - Spacing/density: 4px 리듬, 섹션 리듬 96~128px, 콘텐츠 폭 축소(정밀 인상), 사이드바 밀도 상승.
+  - Composition: 섹션 경계를 배경 카드가 아닌 hairline으로. 제품 데모는 "framed dark panel"로 승격. 장식(글로우/그리드) 제거.
+  - Interaction/motion: 등장 애니메이션 최소화(마이크로 트랜지션 위주, 120~200ms), reduced-motion 존중. focus ring은 액센트.
+- Research side effect disclosure: 중앙 wiki(`~/dev/p/study-all/research`)의 `uiux/visual-language-signal-extraction` 페이지를 **직접 read-only로 열람**(research-query 스킬 미호출 — 컨텍스트 절약 목적). telemetry/write-back 미발생. 외부 fetch: linear.app 블로그, VoltAgent DESIGN.md(raw).
+
+## Baseline
+
+- Type: current-screen
+- Route/params와 data state/source: `/ko`(랜딩), `/ko/docs/overview`, `/en`(랜딩). 정적 콘텐츠(i18n 메시지 + MDX), 외부 data 없음.
+- Exact desktop/mobile viewport: 1440x900 (full-page), 390x844 (full-page).
+- Theme/locale axes: dark(기본)·light, ko(기본)·en.
+- Environment/source revision: local dev(next dev, port 3000), git main@c2280ba, worktree에 packet/artifacts 외 변경 없음.
+- Sensitive-data handling: 실제 사용자·운영 데이터 없음(정적 문서 사이트, 로컬 fixture 불필요). 챗봇 위젯 버튼이 스크린샷에 노출되나 대화 데이터 없음.
+- Capture gap: 없음.
+
+## Capture Manifest
+
+| Artifact path (artifacts/uiux/docs-uiux-redesign/) | Role     | Candidate | Viewport      | Route/state/theme/locale     | Environment/source     | Selection | Evidence class | Sensitive-data handling |
+| -------------------------------------------------- | -------- | --------- | ------------- | ---------------------------- | ---------------------- | --------- | -------------- | ----------------------- |
+| baseline/landing-1440x900-dark-ko.png              | baseline | -         | 1440x900 full | /ko, dark, ko                | next dev, main@c2280ba | N/A       | direction      | 해당 없음(정적 콘텐츠)  |
+| baseline/landing-390x844-dark-ko.png               | baseline | -         | 390x844 full  | /ko, dark, ko                | 상동                   | N/A       | direction      | 상동                    |
+| baseline/landing-1440x900-light-ko.png             | baseline | -         | 1440x900 full | /ko, light, ko               | 상동                   | N/A       | direction      | 상동                    |
+| baseline/landing-1440x900-dark-en.png              | baseline | -         | 1440x900 full | /en, dark, en                | 상동                   | N/A       | direction      | 상동                    |
+| baseline/docs-overview-1440x900-dark-ko.png        | baseline | -         | 1440x900 full | /ko/docs/overview, dark, ko  | 상동                   | N/A       | direction      | 상동                    |
+| baseline/docs-overview-390x844-dark-ko.png         | baseline | -         | 390x844 full  | /ko/docs/overview, dark, ko  | 상동                   | N/A       | direction      | 상동                    |
+| baseline/docs-overview-1440x900-light-ko.png       | baseline | -         | 1440x900 full | /ko/docs/overview, light, ko | 상동                   | N/A       | direction      | 상동                    |
+
+(candidate/final 캡처는 구현 후 추가)
+
+## Four Directions
+
+공통 invariant: 같은 i18n 콘텐츠, 같은 문서 라우트, 다크 우선 + 라이트 지원. Strong recomposition — 최소 두 방향이 기존과 다른 topology.
+
+| ID                     | IA/layout/component composition                                                                                                                                                                                                                                                                  | Strength                                                                 | Risk                                                                                                                         | Preliminary score                                                                   | Implement? |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------- |
+| A `framed-monolith`    | 중앙 정렬 좁은 hero(display 타이포) → 재방문 타임라인을 대형 framed dark panel로 승격 → hairline로 구분된 full-width 섹션(3-layer 가로 3분할, Experience 2×2 hairline 그리드, QuickStart 좌스텝/우코드 2-pane) → CTA 밴드. docs: 밀도 높은 고정 사이드바+본문. 액센트: 라벤더-인디고 계열 자체값 | Linear 문법과 가장 정합, 검증된 마케팅 topology, 구현·모바일 안정        | 익숙한 패턴이라 차별성은 콘텐츠 프레이밍에 의존                                                                              | fit 2 / hierarchy 2 / feasibility 2 / mobile·state 2 = 8                            | yes        |
+| B `layer-ladder`       | 컴팩트 좌정렬 hero(+인라인 설치 명령) → before/after 비교 스트립 → **LAYER 01→02→03 수직 사다리 내러티브**: 각 레이어 행 = 스티키 인덱스 + 설명 + points + 해당 레이어의 QuickStart 코드 인라인 분해 → Experience 압축 그리드 → CTA. docs: A와 동일 셸. 액센트: 일렉트릭 시안-블루 자체값        | "3-레이어" 제품 구조 자체가 IA가 됨 — 서사·차별성 최강, 스크롤 리듬 명확 | QuickStart 스텝↔레이어 매핑 재구성 필요, 스티키 인덱스 모바일 처리, 페이지 길이 증가                                         | fit 2 / hierarchy 2 / feasibility 1 / mobile·state 1 = 6                            | yes        |
+| C `workspace-shell`    | 랜딩 전체를 DevTools 워크스페이스 모사(좌 레일 nav + 중앙 캔버스 데모 + 우 인스펙터 코드), 스크롤 대신 패널 전환 인터랙션 중심                                                                                                                                                                   | 제품(DevTools) 정체성 직결, 임팩트 최대                                  | 모바일 붕괴 위험 최고, 인터랙션 상태 폭증, 콘텐츠 접근성·SEO 저하, 구현 비용 최고                                            | fit 1 / hierarchy 1 / feasibility 0 / mobile·state 0 = 2                            | no         |
+| D `docs-first-economy` | 랜딩 = 한 문장 hero + 설치 명령 + 문서 IA 요약 그리드 + 런타임 이벤트 표. 마케팅 표면 최소화, Vercel식 경제성                                                                                                                                                                                    | 구현 최저비용, 문서 중심 정체성, 유지보수 용이                           | "전면 재작성" 기대 대비 임팩트 부족, visual completion generic 위험, Experience/Timeline 콘텐츠가 갈 곳 잃음(invariant 압박) | fit 1 / hierarchy 2 / feasibility 2 / mobile·state 2 = 7 (fit·완성도 리스크로 하향) | no         |
+
+예비 평가 기준: product fit(속도·정밀함 스토리 전달), hierarchy, feasibility, mobile/state 확장성. **구현 후보: A, B** (C는 feasibility·mobile 탈락, D는 invariant 콘텐츠 수용력과 완성도 기대 미달).
+
+## Implemented Candidates
+
+캡처 공통: 스크롤이 candidate overlay 내부에서 발생해 `--full-page`가 무효 → 실측 scrollHeight를 뷰포트 높이로 지정해 전체 페이지 캡처(`full-*` 파일). `*-900/-844` 파일은 뷰포트 크롭. 전 candidate 캡처는 direction evidence. baseline `full-*` 7장도 같은 방식으로 추가 캡처(위 manifest의 900px 크롭과 동일 route/theme/locale 축, 높이만 실측값: landing 1440x3093·390x5574, docs 1440x4554·390x5645).
+
+- Candidate: A `framed-monolith` (라벤더-인디고 액센트)
+  - Preview surface: `app/[locale]/dev/uiux/a`(+`/docs`) — 격리 dev route, fixed overlay로 기존 셸 위에 렌더. production 무변경.
+  - State coverage: hover/focus-visible CSS 구현, reduced-motion 가드(ux-rise), 다크/라이트 토큰. 탭·copy 인터랙션은 direction 단계에서 정적 표현(통합 시 구현).
+  - Screenshot paths: `artifacts/uiux/docs-uiux-redesign/a/full-landing-1440x4451-{dark,light}-ko.png`, `full-landing-390x6734-dark-ko.png`, `full-landing-1440x4451-dark-en.png`, `full-docs-1440x4142-{dark,light}-ko.png`, `full-docs-390x5110-dark-ko.png` (+뷰포트 크롭 4장)
+  - Artifact roles: candidate / direction evidence
+  - Score: main-thread 15/16 (state extensibility 1). 독립 평가자 14/16 (product fit 1, surface economy 1)
+  - Selection/rejection reason: 완성도·라이트 모드·feasibility 최강. HOW IT FEELS 보더 대비 부족, 데모 카드 푸터 비대칭, QuickStart 좌우 길이 불균형 결함.
+- Candidate: B `layer-ladder` (시안-블루 액센트)
+  - Preview surface: `app/[locale]/dev/uiux/b`(+`/docs`) — 동일 격리 방식.
+  - State coverage: A와 동일(공유 부품).
+  - Screenshot paths: `artifacts/uiux/docs-uiux-redesign/b/full-landing-1440x4406-{dark,light}-ko.png`, `full-landing-390x6498-dark-ko.png`, `full-landing-1440x4406-dark-en.png`, `full-docs-1440x4142-{dark,light}-ko.png`, `full-docs-390x5110-dark-ko.png` (+뷰포트 크롭 4장)
+  - Artifact roles: candidate / direction evidence
+  - Score: main-thread 13/16 (feasibility 1, mobile 1, state 1). 독립 평가자 15/16 (visual completion 1)
+  - Selection/rejection reason: 3-레이어 정체성이 IA 자체가 되는 서사·surface economy 최강, hero 인라인 설치 커맨드가 user job 직결. 사다리 좌측 void, hero 코드 모바일 truncation, "THREE LAYERS" eyebrow ↔ "세 단계" 제목 의미 충돌, 라이트 모드 숫자 대비 부족 결함.
+- 공통 결함: 390px에서 TimelineList 행이 압축됨 → 통합 시 모바일 스택 레이아웃으로 보정.
+- 독립 채점: Explore 서브에이전트(read-only)가 스크린샷+rubric으로 수행. 생성자(main thread)와 분리됨.
+
+## Final Synthesis와 승인
+
+- Decision mode: **synthesize** (제안)
+- Selected base candidate: B `layer-ladder`
+- 가져올 요소 (A로부터): framed demo panel의 밀도·마감(highlights 푸터 정렬 수정 포함), HOW IT FEELS 그리드의 hairline 컨테인먼트(대비 보정), 중앙 CTA 밴드, 라이트 모드 대비 처리.
+- 제외할 요소: A의 중앙 정렬 마케팅 hero(→ B 좌정렬 + 인라인 설치 커맨드 유지), B의 시안 원값(→ 인디고 방향으로 보정한 일렉트릭 블루로 조정 제안), 사다리 좌측 void(→ 좌측 컬럼에 role·포인트 재배치로 보강).
+- 영향 파일(통합 시): app/[locale]/page.tsx + components/landing/* 전면 교체, app/[locale]/docs/layout.tsx + components/layout/_(navbar/footer/sidebar) 교체, components/mdx/_ 재스타일, globals.css 토큰 교체, app/[locale]/layout.tsx(챗봇 제거), components/chat·app/api/chat·lib/ai|vector|cache|ratelimit·scripts 삭제, package.json 의존성 정리.
+- 남은 위험: MDX 컴포넌트 재스타일 시 12개 문서 페이지 회귀 확인 필요, 챗봇 의존성 제거 후 lockfile 갱신, 라이트 모드 대비(AA) 검증.
+- 승인 evidence/date: (대기)
+
+## Terminal State와 Recovery
+
+- Terminal state: (미정)
+- Reason/evidence:
+- Candidate-only cleanup:
+- Previous production behavior recovery 또는 blocker/recovery plan:
+
+## Production Integration과 Cleanup
+
+(승인 후 기록)
+
+## Verification
+
+(통합 후 기록)
+
+## Research Status
+
+- Research status: 중앙 wiki 존재 확인, `uiux/visual-language-signal-extraction` 1페이지 직접 열람(read-only). research-query 스킬 미호출.
+- Freshness: wiki 페이지 updated 2026-06-01, Linear 블로그·DESIGN.md는 2026-07-16 live fetch.
+- Telemetry/write-back: 미발생(직접 열람이므로 query telemetry 없음).

--- a/docs/spec-packets/2026-07-16-prepaint-policy-hardening.md
+++ b/docs/spec-packets/2026-07-16-prepaint-policy-hardening.md
@@ -1,0 +1,204 @@
+# Prepaint 저장·복원 보안 정책 SPEC Packet
+
+날짜: 2026-07-16
+상태: 구현·검증 완료
+대상 repo/surface: `packages/prepaint`, `apps/playground`, 공개 Prepaint 문서
+작업 분류 (Task classification): L-C
+패킷 모드 (Packet mode): interactive
+Artifact: new
+사용자 확정 신호: 2026-07-16 “네” — Q1~Q4 권장 계약 확정 및 구현 시작 승인
+
+## 내가 이해한 요청
+
+- 요청 요약: `docs/update-plan.md`의 Phase 1-B를 구현한다.
+- 사용자가 원하는 결과: 명시적으로 허용한 route만 snapshot을 저장·복원하고, 저장 기간·크기·CSS·lifecycle·CSP·sanitizer 경계를 안전한 공개 계약으로 제공한다.
+- 원문 요청: “Phase 1-B 진행합시다”
+
+## 현재 확정된 것
+
+- Phase 1-A에서 cached DOM hydration을 제거했고, snapshot은 React root 밖의 비상호작용 overlay로만 복원한다.
+- 실제 React 앱은 빈 container에서 `createRoot()`로 시작하고 첫 commit 뒤 overlay를 제거한다.
+- allowlist가 없으면 capture와 restore를 모두 비활성화해야 한다.
+- capture와 boot restore는 하나의 route allowlist 정책을 사용해야 한다.
+- 비허용·만료·크기 초과 snapshot은 복원하지 않고 저장소에서도 제거해야 한다.
+- TTL, 최대 snapshot 크기, CSS 저장 여부를 설정 가능하게 해야 한다.
+- `beforeunload` listener를 제거하고 활성·유휴 시점에 snapshot을 미리 준비해야 한다.
+- runtime CSP nonce를 제공하는 server adapter는 이 작업의 범위가 아니다.
+- `c2280ba`에 반영된 공개 문서 정합성 계약은 보존하고 이 작업의 최종 문서 계약에 포함한다.
+
+## 미정 질문 (Open Questions)
+
+| 질문                                                                                                                                                                | 왜 묻는가                                                                         | 답변이 구현에 미치는 영향                                                              | 상태          |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ------------- |
+| Q1. 표준 Vite API를 `firstTx({ policy: { routes, ttlMs, maxSnapshotBytes, includeStyles } })`로 두고 boot가 직렬화한 동일 정책을 `setupCapture()`가 읽게 할 것인가? | boot는 앱 bundle보다 먼저 실행되므로 build-time 전달 방식이 공개 API를 결정한다.  | plugin option, 전역 정책 전달, manual `boot(policy)` fallback, export type가 정해진다. | answered: yes |
+| Q2. 명시적으로 opt-in한 정책의 기본값을 exact path matching, TTL 7일, 최대 1 MiB, CSS 포함으로 둘 것인가?                                                           | default-off 보안은 유지하면서 기존 replay 품질과 저장 한도를 결정한다.            | validation, size 계산, capture/restore 테스트와 migration note가 달라진다.             | answered: yes |
+| Q3. 최초 migration에서 DB version을 2로 올려 legacy snapshot을 전부 폐기하고, 이후 boot마다 비허용 record를 prune할 것인가?                                         | 기존 record에는 새 정책 provenance가 없어 안전하게 허용 여부를 증명할 수 없다.    | migration 구현과 첫 업데이트 뒤 cold start 동작이 결정된다.                            | answered: yes |
+| Q4. 정적 Vite의 기본을 external self-starting boot asset으로 바꾸고 `inline: true`는 명시적 CSP hash 사용 경로로 남길 것인가?                                       | 현재 inline 기본값과 non-inline boot 호출 방식은 CSP 완료 조건을 만족하지 못한다. | Vite plugin 기본값, HTML 출력, Changeset의 breaking migration 안내가 달라진다.         | answered: yes |
+
+## 임시 가정 (Assumptions)
+
+| 가정                                                                                 | 이유                                                                     | 확정 전 구현 가능? |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------ |
+| A1. route는 현재와 동일하게 `window.location.pathname` exact match를 사용한다.       | glob/prefix semantics는 새로운 제품 기능이며 현재 계약에 없다.           | confirmed          |
+| A2. opt-in 기본 TTL은 기존 7일을 유지한다.                                           | default-off가 보안 경계를 제공하므로 불필요한 replay 품질 변경을 피한다. | confirmed          |
+| A3. 최대 크기는 HTML과 저장되는 style payload를 합한 UTF-8 byte 기준 1 MiB다.        | 문자열 길이보다 저장 비용을 일관되게 측정할 수 있다.                     | confirmed          |
+| A4. CSS 포함은 opt-in 정책 안에서 기본 true이며 `includeStyles: false`로 끌 수 있다. | 명시적 허용 route에서 기존 시각 품질을 보존한다.                         | confirmed          |
+| A5. external boot asset은 정책을 안전하게 직렬화해 자체적으로 `boot()`를 호출한다.   | inline 실행문 없이 CSP-friendly 기본 경로를 제공한다.                    | confirmed          |
+
+## 목표 (Goal)
+
+- 관찰 가능한 결과: 정책이 없거나 현재 route가 allowlist 밖이면 IndexedDB snapshot을 저장·복원하지 않는다.
+- 관찰 가능한 결과: 허용 route에서도 TTL·최대 크기·CSS 설정을 지키고, 이전 정책의 부적격 record를 남기지 않는다.
+- 관찰 가능한 결과: 캡처 준비는 활성·유휴 시점에 수행되고 `beforeunload`에 의존하지 않는다.
+- 사용자/행위자: Vite 기반 CSR React 앱 개발자와 재방문 사용자.
+- source request: `docs/update-plan.md` Phase 1-B.
+
+## 범위 (Scope)
+
+- `PrepaintPolicy` 공개 타입과 표준 Vite plugin 설정을 추가한다.
+- boot와 capture가 동일한 정규화 정책을 소비하도록 한다.
+- default-off, exact allowlist, TTL, 최대 byte 크기, CSS 포함 설정을 구현한다.
+- IndexedDB v2 migration과 부적격 snapshot prune을 구현한다.
+- active/idle preparation 및 `visibilitychange`·`pagehide` persist lifecycle을 구현하고 `beforeunload`를 제거한다.
+- external self-starting boot asset과 inline CSP hash 안내를 구현한다.
+- built-in fallback sanitizer의 threat boundary와 회귀 테스트를 보강한다.
+- Prepaint unit tests, playground 핵심 E2E, packed consumer, 문서, Changeset과 migration note를 갱신한다.
+
+## 제외 범위 (Non-goal)
+
+- cached DOM hydration 또는 direct-restore 경로를 다시 추가하지 않는다.
+- prefix, glob, 정규식, callback 기반 route matcher를 추가하지 않는다.
+- server adapter와 per-response runtime CSP nonce를 구현하지 않는다.
+- Local-First, Tx, DevTools protocol의 동작을 변경하지 않는다.
+- snapshot 암호화나 server-side storage를 추가하지 않는다.
+- sanitizer를 범용 HTML/CSS 보안 라이브러리로 확장하지 않는다.
+
+## 도메인 계약 (Domain Contract)
+
+- 도메인 object/resource: `PrepaintPolicy`, `Snapshot`, IndexedDB `firsttx-prepaint/snapshots`, boot asset, prepared snapshot.
+- 상태 또는 전이: `disabled → eligible → prepared → persisted → restored → handed-off`; `disallowed | expired | oversized | invalid → purged`.
+- 권위: 표준 Vite 사용에서는 plugin의 build-time `policy`가 boot와 runtime capture의 단일 권위다. manual 사용에서는 명시적 `boot(policy)`와 `setupCapture({ policy })`가 같은 정규화 규칙을 사용한다.
+- invariant: allowlist에 없는 route의 snapshot은 새로 저장되지 않고 복원되지 않으며 발견 시 삭제된다.
+- invariant: snapshot payload가 정책 최대 byte 크기를 넘으면 저장·복원되지 않는다.
+- invariant: `includeStyles: false`이면 새 snapshot에 style payload를 저장하지 않고 기존 style payload도 복원하지 않는다.
+- invariant: 정책이 없거나 유효한 route가 하나도 없으면 capture와 restore는 disabled다.
+- invariant: snapshot HTML은 React root의 입력이 되지 않고 overlay에만 사용된다.
+
+## 확정된 결정 (Prior Decisions)
+
+- visual-only overlay handoff와 `createRoot()` 계약은 `@firsttx/prepaint@0.11.0`에서 확정됐다.
+- `overlay`, `overlayRoutes`, `onHydrationError`는 한 릴리스 동안 deprecated no-op으로 유지한다.
+- Local-First CAS/conflict, Tx concurrency, runtime CSP nonce는 별도 phase다.
+
+## 선택지 / 프로토타입 결정 (Option Fan-out / Prototype Decision)
+
+- 고려한 선택지: runtime-only `setupCapture({ routes })`, plugin-only policy, plugin이 boot와 capture에 공유 policy를 제공하는 방식.
+- 선택한 안: plugin 공유 policy + manual explicit fallback.
+- 기각한 대안: runtime-only 설정은 boot restore보다 늦어 default-off restore를 안전하게 제어할 수 없다.
+- 결정 주체/source: 2026-07-16 사용자 “네”, `docs/update-plan.md`의 단일 allowlist 요구.
+- 다시 열 조건: Vite 외 bundler adapter를 같은 릴리스에서 지원해야 하는 요구가 생길 때.
+
+## 제약 (Constraints)
+
+- 반드시 보존: Phase 1-A의 empty-root `createRoot()`와 first-commit overlay removal.
+- 반드시 보존: deprecated option의 타입 호환성 한 릴리스.
+- 반드시 읽을 source: `docs/update-plan.md`, `packages/prepaint/src`, 관련 unit/E2E, 공개 Prepaint 문서.
+- local source-of-truth: 이 packet 확정본과 `docs/update-plan.md` Phase 1-B.
+- 정책 직렬화는 `</script>` 및 line separator를 통한 script breakout을 허용하지 않는다.
+- 새 dependency를 추가하지 않는다.
+
+## 금지 리팩터 (Forbidden Refactor)
+
+- Prepaint 밖 패키지의 공통 storage abstraction을 만들지 않는다.
+- Phase 1-B와 무관한 error hierarchy, DevTools event protocol, build target을 바꾸지 않는다.
+- 기존 사용자 변경이나 unrelated dirty work를 되돌리지 않는다.
+
+## 완료 조건 (Acceptance Criteria)
+
+- [x] AC1: policy 누락·빈 routes에서 capture와 restore가 모두 disabled이고 snapshot DB를 새로 채우지 않는다.
+- [x] AC2: boot와 capture가 동일한 exact route allowlist를 사용하며 비허용 route record를 복원하지 않고 삭제한다.
+- [x] AC3: DB v2 upgrade가 provenance 없는 legacy snapshot을 폐기하고 이후 policy 축소도 부적격 record를 prune한다.
+- [x] AC4: `ttlMs`, `maxSnapshotBytes`, `includeStyles`가 capture와 restore 양쪽에서 일관되게 적용된다.
+- [x] AC5: HTML과 저장 style payload의 UTF-8 byte 크기 초과가 저장 전과 복원 전에 거부·삭제된다.
+- [x] AC6: active/idle 시점에 snapshot을 준비·저장하고 hidden/pagehide에서 마지막 flush를 시도하며 `beforeunload` listener를 등록하지 않는다.
+- [x] AC7: external boot asset이 자체 실행되고 안전하게 직렬화된 policy를 사용하며 inline 경로는 CSP hash 사용법을 문서화한다.
+- [x] AC8: fallback sanitizer가 금지 tag·event attribute·위험 URL을 overlay 삽입 전에 제거하고 CSS threat boundary가 문서화·테스트된다.
+- [x] AC9: slow-JS revisit, route switching, legacy snapshot purge를 playground Playwright로 검증한다.
+- [x] AC10: 공개 API, 기본값 변경, cold-start migration을 Changeset과 영·한 문서에 반영한다.
+- [x] AC11: 실제 packed artifact에서 Vite plugin과 공개 type/export가 소비 가능하다.
+- [x] AC12: 대상 unit test와 root typecheck·lint·test·build가 통과한다.
+
+## 완료 조건 분류 (Acceptance Buckets)
+
+| Bucket                | 필요한가 | Acceptance / 이유                                                               |
+| --------------------- | -------- | ------------------------------------------------------------------------------- |
+| user-visible behavior | yes      | AC1, AC2, AC4, AC6, AC7, AC9, AC10                                              |
+| server authority      | N/A      | client-only snapshot 정책이다.                                                  |
+| client recovery       | yes      | AC2, AC3, AC4, AC5, AC8                                                         |
+| data consistency      | yes      | AC1~AC5                                                                         |
+| performance           | yes      | AC5, AC6                                                                        |
+| accessibility         | N/A      | 비상호작용 overlay 계약을 유지하며 새 UI를 만들지 않는다.                       |
+| observability         | N/A      | 기존 error/capture/restore event 계약을 보존하며 새 protocol은 추가하지 않는다. |
+
+## 엣지 케이스 (Edge Cases)
+
+- Empty/loading/error: policy 또는 routes가 없으면 조용히 cold start하고 capture listener를 최소화한다.
+- Permission/eligibility: 현재 route가 exact allowlist 밖이면 기존 record까지 삭제한다.
+- Retry/duplicate/stale: 중복 setup과 idle callback이 listener·write를 누적하지 않고 최신 prepared snapshot만 저장한다.
+- Partial failure: IndexedDB, style fetch, serialization 실패는 앱 렌더를 막지 않고 cold start로 복구한다.
+- Partial failure: `TextEncoder`, `requestIdleCallback` 미지원 환경은 안전한 fallback을 사용한다.
+
+## 작업 분해 (Task Breakdown)
+
+| Task                                     | Acceptance         | Output files/artifacts                        | Verification               |
+| ---------------------------------------- | ------------------ | --------------------------------------------- | -------------------------- |
+| T1. policy type·정규화·직렬화            | AC1, AC2, AC4, AC7 | `types.ts`, policy module, plugin             | unit/typecheck             |
+| T2. storage migration·prune·restore gate | AC2~AC5            | `utils.ts`, `boot.ts`                         | IndexedDB regression tests |
+| T3. capture payload·idle lifecycle       | AC1, AC4~AC6       | `capture.ts`                                  | lifecycle/size/style tests |
+| T4. sanitizer threat boundary            | AC8                | sanitizer tests and docs                      | malicious fixture tests    |
+| T5. consumer·browser·문서·Changeset      | AC9~AC11           | playground, docs, changeset, consumer fixture | Playwright/pack            |
+| T6. 전체 gate와 verify closure           | AC12               | packet evidence                               | root checks, verify-gate   |
+
+## 검증 계획 (Verification Map)
+
+| Claim group                          | Acceptance IDs  | Type                      | Planned / actual evidence                            | Check safety      | Coverage |
+| ------------------------------------ | --------------- | ------------------------- | ---------------------------------------------------- | ----------------- | -------- |
+| C1. default-off와 route/storage 정책 | AC1, AC2, AC3   | executable                | Prepaint unit + IndexedDB migration tests            | controlled-output | covered  |
+| C2. TTL·size·CSS·lifecycle           | AC4, AC5, AC6   | executable                | capture/boot/lifecycle regression tests              | controlled-output | covered  |
+| C3. CSP·sanitizer 경계               | AC7, AC8        | executable/static         | Vite output tests, malicious fixtures, docs diff     | controlled-output | covered  |
+| C4. 실제 browser/package 소비        | AC9, AC10, AC11 | ui-operational/executable | Playwright, pnpm pack consumer, docs/Changeset audit | controlled-output | covered  |
+| C5. 저장소 회귀 없음                 | AC12            | executable                | target + root typecheck/lint/test/build              | controlled-output | covered  |
+
+- Acceptance coverage check: AC1~~AC12가 C1~~C5 중 정확히 하나에 매핑됐다.
+
+## 증거 / 공백 로그 (Evidence / Gap Log)
+
+- Research evidence: `docs/update-plan.md` Phase 1-B의 React lifecycle·CSP 공식 근거 링크.
+- Local evidence: `PrepaintPolicy`와 동일 policy 정규화가 boot/capture/plugin에 연결됐고 DB schema는 v2다.
+- Verification evidence: `@firsttx/prepaint` lint/typecheck/build와 12 files, 169 unit tests 통과.
+- Browser evidence: `prepaint-handoff.spec.ts`의 slow-JS handoff, exact route switching, v1 purge 3 tests 통과. 전체 playground E2E 20 tests도 중간 검증에서 통과.
+- Consumer evidence: `/tmp/firsttx-prepaint-consumer-20260716-1545`에서 실제 packed `@firsttx/prepaint@0.11.0`과 `@firsttx/shared@0.3.1`을 설치하고 public type/plugin import 및 `dist/firsttx-boot.js` 생성을 확인.
+- Root evidence: `pnpm typecheck`, `pnpm lint`, `pnpm test:run`, `pnpm build` 통과. `git diff --check` 통과.
+- Gap: high-risk 변경에 대한 fresh native `/review`는 제공되지 않았다. 기존 playground/devtools lint warning의 baseline delta는 확인하지 않았다.
+- PASS-with-gaps owner/expiry/trigger, if any: 다음 commit/PR review 시 현재 diff에 대한 fresh review를 수행한다.
+
+## 검증 폐쇄 (Verification Closure)
+
+- Change risk: high
+- Evidence confidence: partial
+- Final verdict: PASS_WITH_GAPS
+- Scope summary: in_scope
+- State drift: none
+- Native review: recommended-not-provided
+- Gap owner/trigger: 다음 commit/PR review에서 fresh review를 수행한다.
+
+## 사용자 피드백 로그 (User Feedback Log)
+
+- 2026-07-16: Phase 1-B 진행 요청.
+- 2026-07-16: Q1~Q4 권장 계약을 “네”로 확정.
+
+## 조정 로그 (Reconciliation Log)
+
+- 2026-07-16: `docs/update-plan.md` Phase 1-B를 기반으로 interactive packet 생성. API·기본값·migration·CSP 결정을 blocker로 분리.
+- 2026-07-16: 사용자 확정에 따라 Q1~~Q4와 A1~~A5를 확정하고 상태를 구현 준비 완료로 전환.
+- 2026-07-16: policy·migration·lifecycle·external asset·sanitizer·문서·Changeset을 구현하고 unit, Playwright, packed consumer, root gate 증거로 구현·검증 완료 상태로 전환.

--- a/docs/spec-packets/2026-08-08-build-artifact-index.md
+++ b/docs/spec-packets/2026-08-08-build-artifact-index.md
@@ -1,0 +1,138 @@
+# T2′ — build artifact 인덱스 전환
+
+- 상태: 구현 완료, 검증 통과
+- 현재 작업 분류: L-C (runtime retrieval 계약 변경 + 배포 구성)
+- packet mode: interactive
+- 작성일: 2026-08-08
+- 상위 계획: [FirstTx Docs RAG defense plan](../plans/2026-08-07-rag-defense-plan.md)
+- 선행: [T1 deterministic index plan](2026-08-07-deterministic-index-plan.md), [T5a retrieval 평가](2026-08-08-retrieval-evaluation.md)
+- 대체: 상위 계획의 T2(run manifest)와 T3(staging + active pointer)
+
+## 결정 배경
+
+2026-08-08 실측으로 호스팅을 확정했다.
+
+- 검색 방식은 embedding 유지 — Hit@3 85.7% vs BM25 57.1%
+- 187 chunk brute-force 검색 **0.38ms**, float32 packed **1.10MB**, base64 디코드 0.3ms
+- 성장 한계는 약 3,300 chunk(18배). 그 이상은 Vercel Fluid Compute
+- 무료 티어 vector DB가 미사용으로 **실제 삭제**됐다. 원래 T2·T3 설계는 빌드 실패는 막지만 공급자 삭제와 문서-인덱스 drift는 막지 못한다
+
+artifact는 저장소에 커밋한다. 빌드에 provider credential이 필요 없고, 인덱스 변경이 PR diff에 보이며, T1의 content revision으로 staleness를 CI가 강제할 수 있다.
+
+## 목표
+
+1. 배포된 Chat이 외부 vector DB 없이 retrieval을 수행한다.
+2. 문서와 인덱스가 어긋난 채 배포될 수 없다.
+3. 빌드가 provider credential 없이 성공한다.
+4. 측정된 retrieval 품질(Hit@3 85.7%, MRR 0.643)이 전환 전후로 동일하다.
+5. Upstash Vector 의존을 제거한다.
+
+## 범위
+
+- float32 packed artifact 형식과 직렬화/역직렬화
+- artifact 생성 CLI (기존 `ai` 대체)
+- runtime brute-force search — `lib/vector/search.ts` 대체
+- artifact를 함수 번들에 포함시키는 Next.js 설정
+- artifact revision과 현재 문서 revision을 대조하는 CI staleness gate
+- 평가 러너를 공유 runtime search로 재배선
+- README와 운영 문서 갱신
+
+## 제외
+
+- Redis와 rate limit — Chat 재활성화 시점의 별도 작업
+- Chat 프로덕션 재활성화
+- canonical 문서 어휘 보강 (`ko-6` miss 대응)
+- 평가 case 변경
+- chunk 경계·topK·minScore 튜닝
+- retrieval inspection API와 ops UI (T5b, T6)
+
+## 확정된 결정
+
+2026-08-08 사용자가 4개 모두 권장안으로 확정했다.
+
+1. **artifact 읽기 방식** → `lib/vector/index-artifact.json`을 **모듈로 import**. 번들러가 자동 포함하므로 `outputFileTracingIncludes` 누락으로 프로덕션에서만 실패하는 경로가 없다. tsc는 1.67MB JSON import를 문제없이 처리했다.
+2. **형식** → base64 packed `Float32Array`. 최종 artifact 1.67MB(embeddings 1.46MB + chunk 본문).
+3. **CI gate** → `pr.yml`의 `verify` job에 `ai:check-index` 단계 추가. 외부 호출이 없어 credential 불필요.
+4. **기존 `ai`** → `ai:build-index`로 대체. `scripts/main.ts`, `scripts/vector.ts`, `scripts/cache.ts`와 `@upstash/vector` 의존을 제거했다.
+
+## 도메인 계약
+
+```ts
+interface PackedIndexArtifact {
+  artifactVersion: 1;
+  embeddingModel: string;
+  indexContractVersion: string;
+  dimensions: number;
+  revisions: Record<'ko' | 'en', string>;
+  chunks: Array<{ id; title; section; source; content; locale }>;
+  embeddings: string;
+}
+```
+
+규칙:
+
+1. `embeddings`는 `chunks` 순서대로 이어붙인 `Float32Array`의 base64다.
+2. `revisions`는 T1의 `createIndexPlan`이 만든 locale별 content revision이다.
+3. runtime은 `revisions`와 `embeddingModel`을 읽기 전용으로만 쓴다.
+4. search는 cosine을 `(1 + cos) / 2`로 정규화해 기존 점수 의미를 보존한다.
+5. topK와 minScore는 `lib/ai/rag.ts`의 기존 상수를 계속 쓴다.
+
+## Acceptance Criteria
+
+- AC1: `lib/vector/search.ts`가 Upstash를 import하지 않고 동일한 `SearchResult` 형태를 반환한다.
+- AC2: 전환 후 `ai:evaluate`의 Hit@3와 MRR이 전환 전과 같다.
+- AC3: provider credential이 전혀 없는 환경에서 `pnpm build`가 성공한다.
+- AC4: 문서를 고치고 artifact를 재생성하지 않으면 CI가 실패한다.
+- AC5: 배포 번들에 artifact가 포함되어 프로덕션 Chat 경로가 동작한다.
+- AC6: `@upstash/vector` 의존과 `scripts/vector.ts`가 제거된다.
+- AC7: score 정규화가 유지되어 기존 minScore 의미가 바뀌지 않는다.
+- AC8: docs typecheck, lint, format, 전체 unit test, production build가 통과한다.
+- AC9: README와 운영 문서가 새 명령과 갱신 절차를 설명한다.
+
+## 위험
+
+| 위험                                            | 대응                                                        |
+| ----------------------------------------------- | ----------------------------------------------------------- |
+| artifact가 번들에 안 들어가 프로덕션에서만 실패 | 미정 질문 1에서 import 방식을 택해 실패 모드 제거           |
+| 문서만 고치고 artifact 갱신 누락                | CI staleness gate (AC4)                                     |
+| git 비대화                                      | 문서 변경 시에만 1.46MB 갱신. 변경 빈도가 낮음              |
+| corpus 성장으로 번들 압박                       | 약 3,300 chunk에서 재검토. `ai:plan`의 chunk 수로 조기 관찰 |
+| 전환 중 retrieval 품질 회귀                     | 전환 전후 `ai:evaluate` 동일 수치 확인 (AC2)                |
+
+## Verification
+
+```bash
+pnpm --filter @firsttx/docs typecheck
+pnpm --filter @firsttx/docs lint
+pnpm --filter @firsttx/docs test:run
+pnpm --filter @firsttx/docs format:check
+pnpm --filter @firsttx/docs build
+pnpm --filter @firsttx/docs ai:evaluate
+pnpm --filter @firsttx/docs ai:probe-unknown
+```
+
+credential을 제거한 셸에서 `build`가 통과하는지 별도로 확인한다.
+
+## 검증 결과 (2026-08-08)
+
+| AC                                          | 결과                                                                                      |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| AC1 search가 Upstash 미사용, 동일 형태 반환 | 통과 — `lib/vector/search.ts`가 artifact brute-force로 `SearchResult` 반환                |
+| AC2 retrieval 품질 불변                     | **통과 — Hit@3 85.7%, MRR 0.643, miss `ko-6`·`en-2`로 전환 전과 동일**                    |
+| AC3 credential 없이 build 성공              | 통과 — 5개 env 제거 후 production build 성공                                              |
+| AC4 문서만 고치면 CI 실패                   | 통과 — 문서 임시 수정 시 revision 불일치로 non-zero exit 확인 후 복원                     |
+| AC5 배포 번들에 artifact 포함               | 통과 — 모듈 import이므로 번들러가 포함. tracing 설정 불필요                               |
+| AC6 Upstash 의존 제거                       | 통과 — `@upstash/vector`, `scripts/vector.ts`, `scripts/main.ts`, `scripts/cache.ts` 제거 |
+| AC7 score 정규화 유지                       | 통과 — `(1 + cos) / 2` 유지, unit test로 고정                                             |
+| AC8 native checks                           | 통과 — typecheck, lint, format, 60 tests, build                                           |
+| AC9 문서 갱신                               | 통과 — README 파이프라인·명령 경계 갱신                                                   |
+
+부수 정리: `scripts/types.ts`의 `ChunkWithEmbedding`이 이 변경으로 미사용이 되어 함께 제거했다.
+
+## Closure
+
+- 현재 verdict: CLOSED — AC1~AC9 충족
+- implementation: DONE
+- change risk: normal — runtime retrieval 구현이 바뀌었으나 인터페이스와 측정 품질은 동일하다
+- state drift: 없음 — 외부 서비스 상태를 변경하지 않았다
+- 다음 gate: canonical 문서 어휘 보강(`ko-6`)과 Chat 재활성화(Redis rate limit)

--- a/docs/spec-packets/2026-08-08-retrieval-evaluation.md
+++ b/docs/spec-packets/2026-08-08-retrieval-evaluation.md
@@ -1,0 +1,318 @@
+# T5a — 고정 질문 retrieval 평가
+
+- 상태: 구현 완료, 측정은 credential 부재로 차단
+- 현재 작업 분류: M-C
+- packet mode: interactive
+- 작성일: 2026-08-08
+- 상위 계획: [FirstTx Docs RAG defense plan](../plans/2026-08-07-rag-defense-plan.md)
+- 선행 task: [T1 deterministic index plan](2026-08-07-deterministic-index-plan.md) (완료)
+
+## 범위 분리 이유
+
+상위 계획의 T5는 retrieval inspection API와 고정 질문 평가를 함께 묶는다. 이 packet은 그중 **평가 러너만** 소유하고 HTTP API와 ops UI는 T5b로 미룬다.
+
+근거는 두 가지다.
+
+1. 평가 러너는 lifecycle 기계장치(T2 manifest, T3 activation)에 의존하지 않는다. 현재 `ko`, `en` namespace에 그대로 실행할 수 있으므로 T2보다 먼저 값을 낸다.
+2. 2026-08-08 논의에서 vector DB 의존 자체를 재검토하기로 했다. 검색 구조를 바꾸든 유지하든 **바꾸기 전후를 비교할 자**가 먼저 필요하고, 그 자가 이 packet이다. 반대로 T5b의 retrieval API는 canonical href helper와 rate limit 예산 gate에 묶여 있어 지금 닫을 이유가 약하다.
+
+## 내가 이해한 요청
+
+"검색 품질이 문제인가, 안정성이 문제인가"를 감이 아니라 숫자로 판정한다. KO/EN 고정 질문을 실행 전에 확정하고, 현재 runtime과 같은 경로로 검색해 Hit@3와 MRR을 재현 가능한 artifact로 남긴다.
+
+## 현재 확정된 것
+
+- runtime 검색 경로는 `retrieveContext(query, 8, locale)` -> `searchDocs(embedding, 8, 0.5, locale)`이다.
+- 고정 namespace는 `ko`, `en`이고 minScore는 0.5, topK는 8이다.
+- chunk `id`는 `{locale}-{docId}-{n}` 형식의 **위치 기반**이라 문서 편집 시 밀린다. 평가 case는 `id`를 고정하지 않는다.
+- `source`(`troubleshooting.ko.mdx`)와 `section`(H2 제목)은 안정적이므로 기대값의 기준으로 쓴다.
+- 평가는 외부 상태를 읽기만 한다. embedding 생성과 vector query만 수행하고 upsert, reset, pointer 변경을 하지 않는다.
+- 평가 case는 실행 결과를 보기 전에 확정한다. 과적합 방지가 이 task의 핵심 제약이다.
+
+## 해소된 질문
+
+1~2번은 2026-08-08 사용자가 권장안으로 확정했고, 3번은 측정 정합성 문제라 구현자가 판단했다.
+
+1. **Hit 판정 단위** → **source + section**. case가 `expectedSections`를 주면 둘 다 일치해야 hit다. `tx.ko.mdx`처럼 chunk가 많은 문서에서 아무 조각이나 맞힌 것을 성공으로 세면 metric이 낙관적으로 부푼다.
+2. **결과 커밋 여부** → **case만 커밋**. 실행 결과는 `apps/docs/evaluations/results/`에 timestamp 파일로 남기고 gitignore한다.
+3. **query embedding 캐시** → **쓰지 않는다**. 현재 캐시 key(`lib/cache/embedding-cache.ts`)는 model을 포함하지 않는 text hash라 모델 변경 뒤 옛 embedding을 돌려줘 측정값을 오염시킨다. 러너는 `scripts/embed.ts`의 uncached 경로를 쓴다.
+
+## 목표
+
+1. KO/EN 고정 질문으로 Hit@3와 MRR을 반복 측정한다.
+2. miss를 숨기지 않고 어떤 질문이 무엇을 대신 검색했는지 남긴다.
+3. 같은 index와 같은 case에서 결과가 재현된다.
+4. 검색 성공과 **프롬프트 도달**을 분리해 관찰한다.
+5. 이후 검색 구조를 바꿀 때 같은 자로 전후를 비교한다.
+
+## 범위
+
+- `RetrievalEvaluationCase` 계약과 KO/EN 14개 case 파일
+- 현재 runtime과 같은 경로로 검색하는 평가 러너
+- Hit@3, MRR, per-case miss 기록 계산
+- context truncation 도달 여부 기록
+- `ai:evaluate` package script
+- metric 계산 로직의 unit test (외부 호출 없이 fixture로)
+- 결과 artifact schema
+
+## 제외
+
+- retrieval HTTP API와 ops UI (T5b)
+- `IndexRun`, active pointer와 lifecycle 연동 (T2~T4)
+- 생성 답변 정확도 자동 판정 (LLM-as-judge)
+- minScore, topK, chunk 경계 튜닝 — 이번엔 **측정만** 하고 바꾸지 않는다
+- 검색 구조 변경 (vector -> BM25/build artifact 등)
+- 기존 `ai`, `ai:plan` 동작 변경
+
+## 도메인 계약
+
+```ts
+interface RetrievalEvaluationCase {
+  id: string;
+  locale: 'ko' | 'en';
+  query: string;
+  expectedSources: string[];
+  expectedSections?: string[];
+  intent: 'symptom' | 'contract';
+  layer: 'prepaint' | 'local-first' | 'tx' | 'general';
+}
+
+interface RetrievalEvaluationResult {
+  caseId: string;
+  locale: 'ko' | 'en';
+  hitRank: number | null;
+  reciprocalRank: number;
+  retrieved: Array<{
+    rank: number;
+    score: number;
+    source: string;
+    section: string;
+    withinContextBudget: boolean;
+  }>;
+}
+```
+
+규칙:
+
+1. `hitRank`는 기대값과 일치하는 첫 결과의 1-based rank이며 없으면 `null`이다.
+2. `expectedSections`가 있으면 `source`와 `section`이 모두 일치해야 hit다. 없으면 `source`만 본다.
+3. `reciprocalRank`는 `hitRank`가 있으면 `1 / hitRank`, 없으면 `0`이다.
+4. Hit@3는 `hitRank !== null && hitRank <= 3`인 case의 비율이다.
+5. MRR은 전체 case `reciprocalRank`의 평균이다.
+6. `withinContextBudget`은 그 chunk가 4,000자 context 예산 안에 들어가 실제 프롬프트에 도달하는지를 뜻한다. metric에는 넣지 않고 진단 정보로만 남긴다.
+7. minScore 0.5에 걸려 결과가 비면 그 case는 `hitRank: null`이다. 이것도 정상적인 측정 결과이며 실패로 숨기지 않는다.
+
+## 고정 평가 case 초안
+
+문서 9개를 모두 덮고, 세 layer 각각에 증상형과 계약형을 배치했다. 질문 문구는 문서 표현을 그대로 쓰지 않고 사용자가 쓸 법한 말로 적었다.
+
+| #    | locale | layer       | intent   | query                                                                    | expectedSources                                | expectedSections                            |
+| ---- | ------ | ----------- | -------- | ------------------------------------------------------------------------ | ---------------------------------------------- | ------------------------------------------- |
+| ko-1 | ko     | prepaint    | symptom  | 재방문해도 매번 빈 화면부터 시작해요. 저장된 화면이 왜 안 쓰이나요?      | `troubleshooting.ko.mdx`                       | Prepaint가 replay되지 않음                  |
+| ko-2 | ko     | prepaint    | contract | 복원된 화면에서 버튼이 안 눌리는데 버그인가요?                           | `troubleshooting.ko.mdx`, `prepaint.ko.mdx`    | —                                           |
+| ko-3 | ko     | local-first | contract | useModel이랑 useSyncedModel 중에 뭘 써야 하나요?                         | `local-first.ko.mdx`                           | 2. React 훅: `useModel` vs `useSyncedModel` |
+| ko-4 | ko     | tx          | symptom  | 타임아웃이 났는데 서버 요청이 계속 진행돼요                              | `troubleshooting.ko.mdx`, `tx.ko.mdx`          | —                                           |
+| ko-5 | ko     | general     | contract | 우리 앱에 이 라이브러리가 맞는지 어떻게 판단하나요?                      | `overview.ko.mdx`                              | 3. 어떤 앱에 잘 맞나요?                     |
+| ko-6 | ko     | general     | contract | 앱 진입점을 어떻게 바꿔야 하나요?                                        | `getting-started.ko.mdx`                       | —                                           |
+| ko-7 | ko     | general     | contract | 세 기능을 같이 쓸 때 어떤 순서로 붙이나요?                               | `patterns.ko.mdx`, `overview.ko.mdx`           | —                                           |
+| en-1 | en     | prepaint    | symptom  | Revisiting the app still shows a blank screen instead of the cached view | `troubleshooting.en.mdx`                       | Prepaint does not replay                    |
+| en-2 | en     | local-first | symptom  | The data is empty on the very first render                               | `troubleshooting.en.mdx`, `local-first.en.mdx` | —                                           |
+| en-3 | en     | tx          | contract | Does the step that failed also get its compensation run?                 | `troubleshooting.en.mdx`, `tx.en.mdx`          | —                                           |
+| en-4 | en     | tx          | contract | How do I make a transaction step retry on failure?                       | `tx.en.mdx`                                    | 3. `tx.run` and retry                       |
+| en-5 | en     | general     | symptom  | Some fields look empty in the debugging panel                            | `troubleshooting.en.mdx`, `devtools.en.mdx`    | —                                           |
+| en-6 | en     | general     | contract | Where can I look up every option this library accepts?                   | `reference.en.mdx`                             | —                                           |
+| en-7 | en     | local-first | contract | How do I keep two browser tabs in sync?                                  | `local-first.en.mdx`                           | 3. Multi-tab sync & BroadcastChannel        |
+
+covered documents: `troubleshooting`, `prepaint`, `local-first`, `tx`, `overview`, `getting-started`, `patterns`, `devtools`, `reference` — 9/9.
+
+## CLI 계약
+
+```bash
+pnpm --filter @firsttx/docs ai:evaluate
+```
+
+- 두 locale의 case를 모두 실행하고 locale별 Hit@3, MRR과 전체 요약을 stdout에 사람이 읽는 형태로 출력한다.
+- raw 결과는 결과 디렉터리에 timestamp 파일로 남긴다.
+- Hit@3가 임계 미만이면 miss 목록을 함께 출력한다. 프로세스는 실패로 종료하지 않는다. 이번 task의 목적은 gate가 아니라 측정이다.
+- credential이 없으면 stable message와 non-zero exit로 거절한다.
+
+## Acceptance Criteria
+
+- AC-E1: KO/EN 합계 14개 case가 저장소에 고정되고 9개 문서를 모두 덮는다.
+- AC-E2: hit 판정, MRR, Hit@3 계산이 외부 호출 없는 fixture unit test로 검증된다.
+- AC-E3: 러너가 runtime과 같은 embedding model, chunk 경계, embedding 입력 문자열, topK, minScore와 score 정규화를 사용한다.
+- AC-E4: 결과 artifact에 case별 rank, score, source, section과 miss가 남는다.
+- AC-E5: 같은 index와 case에서 **metric이** 재현된다. 정확한 rank 순서는 embedding provider가 결정적이지 않아 보장 대상이 아니다.
+- AC-E6: 평가 실행이 upsert, reset, pointer를 변경하지 않는다.
+- AC-E7: docs typecheck, lint, format:check와 전체 unit test가 통과한다.
+- AC-E8: 실행 결과 요약과 해석이 상위 계획에 기록된다.
+
+## Verification map
+
+| Claim                                       | Type              | 연결 AC  | Planned evidence                            | Safety        |
+| ------------------------------------------- | ----------------- | -------- | ------------------------------------------- | ------------- |
+| C1 metric 계산이 정확함                     | executable        | AC-E2    | fixture unit test                           | safe-no-write |
+| C2 case가 문서 전체를 덮고 실행 전에 고정됨 | static            | AC-E1    | case 파일 리뷰, 이 packet의 초안 표         | safe-no-write |
+| C3 러너가 runtime 경로와 동일함             | static            | AC-E3    | call-site diff review                       | safe-no-write |
+| C4 실행이 외부 상태를 바꾸지 않음           | static/executable | AC-E6    | import graph 검토, 실행 전후 namespace 확인 | external-read |
+| C5 결과가 재현됨                            | executable        | AC-E4~E5 | 2회 실행 비교                               | external-read |
+
+## 실행 승인 경계
+
+`ai:evaluate`는 외부 호출을 한다. 규모는 다음과 같다.
+
+- OpenAI embedding 14회 (질의당 1회, 합계 약 500 토큰 미만)
+- Upstash Vector query 14회
+
+둘 다 읽기이고 예상 비용은 1센트 미만이지만, 상위 계획의 "외부 상태를 읽거나 바꾸는 검증"에 해당하므로 **사용자 승인 뒤에 실행한다.** 구현과 unit test까지는 승인 없이 진행할 수 있다.
+
+## Evidence / Gap log
+
+| 날짜       | 종류     | 내용                                                                                                                                                                      |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-08 | evidence | chunk `id`가 위치 기반이라 기대값 기준으로 부적합함을 실제 chunk 출력으로 확인했다.                                                                                       |
+| 2026-08-08 | evidence | runtime은 topK 8, minScore 0.5, 고정 locale namespace를 사용한다.                                                                                                         |
+| 2026-08-08 | evidence | `lib/cache/embedding-cache.ts` key에 model이 없어 모델 변경 뒤 측정 오염 위험이 있다.                                                                                     |
+| 2026-08-08 | evidence | 초안 14개 case의 기대 source와 section이 실제 canonical 문서에 존재함을 unit test로 검증했다.                                                                             |
+| 2026-08-08 | evidence | `scripts/embed.ts`가 OpenAI client를 모듈 로드 시점에 생성해, credential guard보다 먼저 SDK stack trace로 터졌다. `vector.ts`, `search.ts`와 같은 lazy 패턴으로 교정했다. |
+| 2026-08-08 | evidence | runtime의 topK 8과 minScore 0.5를 `lib/ai/rag.ts` 상수로 승격해 러너와의 drift를 구조적으로 제거했다. chat route의 중복 literal도 상수 참조로 바꿨다.                     |
+| 2026-08-08 | gap      | 로컬 `.env.local`에 `OPENAI_API_KEY`가 없어 실제 측정을 실행하지 못했다. Upstash Vector credential 4종은 존재한다.                                                        |
+
+## 측정 결과 (2026-08-08)
+
+Upstash 무료 티어 DB 2개가 미사용으로 삭제돼 있어(Vector: 빈 응답, Redis: 연결 실패) 사용자 승인 아래 로컬 artifact 경로로 측정했다. 프로덕션 `firsttx.store`는 정상이고 Chat이 노출되지 않아 긴급도는 없었다.
+
+> **정정 (2026-08-08 후속)**: 아래 100%는 case 14건 중 7건이 `expectedSections`를 지정하지 않아 **source 단위로만 판정**된 결과다. 사용자가 확정한 판정 단위는 "source + section"이었으므로 이는 계약 위반이었다. 7건에 섹션을 고정한 뒤 재측정한 정직한 값은 **Hit@3 85.7%, MRR 0.643**이다. 아래 표는 기록으로 남긴다.
+
+| 지표                       | KO        | EN        | 전체      |
+| -------------------------- | --------- | --------- | --------- |
+| cases                      | 7         | 7         | 14        |
+| Hit@3 (느슨한 source 판정) | 100%      | 100%      | 100%      |
+| **Hit@3 (섹션 고정 후)**   | **85.7%** | **85.7%** | **85.7%** |
+| **MRR (섹션 고정 후)**     | **0.595** | **0.690** | **0.643** |
+
+섹션 고정 후 드러난 실제 miss 2건:
+
+- `ko-6` "앱 진입점을 어떻게 바꿔야 하나요?" — 정답 섹션 `3. 엔트리 포인트 교체 (createFirstTxRoot)`가 top-8에 아예 없다. 대신 overview와 getting-started의 다른 섹션이 잡힌다. 점수가 0.624~0.649로 극도로 평평해 변별력이 없다.
+- `en-2` "The data is empty on the very first render" — `Local-First data is not ready`를 못 찾고 getting-started의 훅 사용 섹션이 잡힌다.
+
+이 정정은 **결과를 본 뒤 기대값을 조인 것**이므로 사전 등록된 측정이 아니다. 다만 판정 단위를 원래 확정안에 맞춘 것이지 숫자를 맞추려 조정한 것은 아니다.
+
+- artifact: 187 chunk, JSON 5.47 MB (float를 십진 문자열로 저장한 크기이며 Float32 base64면 약 1.5 MB)
+
+### 함께 드러난 사실
+
+1. **`minScore: 0.5`는 사실상 no-op이다.** Upstash는 cosine을 `(1 + cos) / 2`로 정규화하므로 0.5는 raw cosine 0.0을 뜻한다. 관측된 최저 점수는 0.6240(raw cosine 0.248)이었고 **112개 결과 중 0개가 걸러졌다.** 의도한 품질 임계처럼 보이지만 음의 유사도만 제거한다.
+2. **topK 8의 약 40%는 프롬프트에 도달하지 못한다.** 4,000자 context 예산 안에 들어간 chunk는 case당 평균 4.8개였다. 다만 **모든 hit는 예산 안에 있었으므로** 이번 case에서 실제 손실은 없었다.
+3. **metric은 재현되지만 정확한 rank 순서는 아니다.** 2회 실행에서 Hit@3와 MRR, 모든 hitRank는 동일했으나 112개 중 72개 점수가 최대 2.1e-4 차이를 보여 근접 결과의 순서가 바뀌었다. 원인은 OpenAI embedding의 비결정성이다. query embedding을 캐시하면 bit-stable해지지만, 현재 캐시 key에 model이 없어 그 대가로 모델 변경 시 오염을 얻는다. model 포함 cache key(상위 계획 P1)가 이 둘을 동시에 푼다.
+
+### 2026-08-08 추가 측정 — out-of-domain 8건
+
+기존 14건은 모두 답이 존재하는 질문이라 **답이 없는 질문 경로가 미검증**이었다. 문서에 실제로 부재한 주제 8건(KO 4 / EN 4)을 추가했고, 절반은 의도적으로 in-domain 어휘를 재사용한다(`트랜잭션 보상 로직의 단위 테스트`, `Prepaint 스냅샷에서 다국어`). 부재 근거는 unit test가 corpus 문자열로 검증한다.
+
+| 항목                        | 값                                                      |
+| --------------------------- | ------------------------------------------------------- |
+| OOD 질문이 결과를 받은 비율 | **8/8** — 전부 topK 8개를 가득 채워 반환                |
+| 정답의 최저 점수            | 0.6332                                                  |
+| OOD 질문의 최고 점수        | **0.7966** (`FirstTx를 React Native에서 쓸 수 있나요?`) |
+| 두 분포                     | **완전히 겹침.** 8건 전부가 정답 최저점보다 높다        |
+
+**결론: `minScore`는 튜닝으로 고칠 수 없다.** 0.5가 no-op인 것이 문제가 아니라, 어떤 값을 넣어도 out-of-domain 질문을 거르면서 정답을 지키는 임계값이 존재하지 않는다. 0.65로 올리면 OOD 8건이 그대로 통과하면서 정답만 잘려 나간다. retrieval 층에는 방어선이 없고, 유일한 방어는 프롬프트의 UNKNOWN 규칙이다.
+
+### UNKNOWN 규칙 실측 (`ai:probe-unknown`, 4회 × 8건 = 32 generation)
+
+| 분류         | 뜻                            | 관측                            |
+| ------------ | ----------------------------- | ------------------------------- |
+| strict       | UNKNOWN 문구만 반환           | 대체로 EN 3건이 고정적으로 해당 |
+| acknowledged | UNKNOWN 문구 + 주변 정보 병기 | KO 3건 + EN 1건이 대체로 해당   |
+| **violated** | UNKNOWN 없이 답을 생성        | **32건 중 2건**                 |
+
+- 위반 2건은 `ood-ko-2`(1회), `ood-ko-4`(1회)로 **모두 KO이고 모두 in-domain 어휘 재사용 case**다.
+- 같은 질문이 실행마다 다르게 분류된다. 즉 **위반은 결정적이지 않고 간헐적**이며, 1회 실행으로는 안전하다고 판정할 수 없다.
+- 위반 사례는 순수 날조가 아니라 "문서에 구체적 API는 없다"고 인정한 뒤 **문서가 주지 않은 지침을 이어서 생성**하는 형태였다.
+- EN 4건에서는 4회 실행 내내 위반이 없었다. KO 프롬프트가 EN보다 약할 가능성이 있으나 표본이 작아 단정하지 않는다.
+
+### UNKNOWN 규칙 수정과 재측정 (2026-08-08)
+
+위반의 원인은 프롬프트 안의 충돌이었다. `### 답변 형식`의 "확실하지 않은 내용은 '문서에서 확인이 필요합니다'라고 명시하세요"가 **UNKNOWN 규칙의 탈출구**로 작동해, 모델이 "문서에 없다"고 인정한 뒤 문서에 없는 지침을 이어 쓰는 것을 허용했다.
+
+UNKNOWN 규칙을 KO/EN 대칭으로 3갈래 판정으로 교체했다.
+
+1. CONTEXT가 질문에 답한다 → 답한다
+2. CONTEXT가 관련은 있으나 답하지 않는다 → CONTEXT에 실제 있는 사실만 짧게 전하고 UNKNOWN 문장을 포함한다. **문서에 없는 방법·절차·권장사항을 이어서 설명하지 않는다**
+3. CONTEXT가 무관하다 → UNKNOWN 문장만 반환한다
+
+과잉 거부를 막기 위해 "CONTEXT에 답이 있는데 UNKNOWN으로 회피하지 말 것"과 "애매하면 1번이나 2번"을 함께 명시했고, 충돌하던 탈출구 문장은 제거했다.
+
+|                                          | 변경 전  | 변경 후                   |
+| ---------------------------------------- | -------- | ------------------------- |
+| violated (UNKNOWN 없이 생성)             | 2 / 32   | **0 / 56**                |
+| 과잉 거부 (정답이 context에 있는데 거부) | 1건 관측 | 1건 관측 (`en-5`, 간헐적) |
+
+`en-5`의 간헐적 과잉 거부는 변경 전 baseline에도 있었으므로 이번 변경이 만든 회귀가 아니다.
+
+probe도 함께 고쳤다. 기존에는 `ko-6`처럼 **retrieval이 정답을 못 찾은 경우의 거부까지 과잉 거부로 집계**했는데, 이는 오히려 올바른 동작이다. 이제 정답이 실제로 context에 있는지 확인한 뒤 `과잉 거부`와 `정당한 거부`를 분리한다.
+
+### miss 2건 진단과 keyword-only recall probe (2026-08-08)
+
+**miss 진단** — 정답 섹션의 전체 corpus 내 순위를 직접 계산했다.
+
+- `ko-6` "앱 진입점을 어떻게 바꿔야 하나요?": 정답 `3. 엔트리 포인트 교체`가 **14위/88** (0.6145, 1위와 0.0347 차). 원인은 어휘 간극이다 — 질문은 "진입점", 문서는 "엔트리 포인트"만 쓴다.
+- `en-2` "The data is empty on the very first render": 정답 `Local-First data is not ready`가 **9위/99** (0.6681, 1위와 0.0151 차). top-8에서 한 계단 모자라고, top 10 점수폭이 0.015로 평평해 순위가 사실상 동률이다.
+
+**keyword-only recall** ([[llm-retrieval/retrieval-architecture-selection]]의 검증 probe) — BM25(한국어 문자 bigram 토큰화, latin 식별자 보존)를 같은 chunk corpus에 돌려 임베딩과 비교했다. 순수 로컬 계산이며 API 호출이 없다.
+
+| 지표                  | embedding | keyword (BM25)                                                        |
+| --------------------- | --------- | --------------------------------------------------------------------- |
+| Hit@3                 | **85.7%** | 57.1%                                                                 |
+| MRR                   | **0.643** | 0.387                                                                 |
+| keyword만의 추가 miss | —         | `en-1`(패러프레이즈), `en-6`(공유 어휘 없음), `ko-5`·`ko-7` rank 하락 |
+| OOD 8건에 결과 반환   | 8/8       | **8/8 — keyword도 OOD를 거르지 못함**                                 |
+
+판정:
+
+1. **query 어휘 축은 임베딩 쪽으로 기운다.** 사용자형 질문의 상당수가 패러프레이즈("blank screen" vs "does not replay")라 keyword가 크게 진다. 임베딩 유사도는 이 corpus에서 값어치를 실증했다. — 단, 이는 **검색 방식**의 판정이며 vector DB 호스팅 판정이 아니다. 로컬 artifact로 같은 품질이 나온다는 사실은 그대로다.
+2. **keyword도 OOD를 거르지 못한다.** OOD 질문이 in-domain 일반 어휘(앱, Prepaint, package)를 포함하므로 BM25도 8/8 결과를 반환했다. "keyword 검색이면 자연히 무관 질문이 걸러진다"는 가설은 이 질문 세트에서 기각됐다.
+3. **miss 2건은 검색 방식의 문제가 아니라 문서 어휘 공백이다.** `ko-6`은 embedding과 keyword가 **둘 다** miss다. "진입점"이라는 사용자 어휘가 canonical 문서에 존재하지 않는 한 어떤 검색도 이길 수 없다. 대응은 retrieval 튜닝이 아니라 **canonical MDX에 동의어를 병기**하는 콘텐츠 수정이다(예: "엔트리 포인트(진입점)"). 이는 화면 문서와 RAG가 source를 공유하므로 화면에도 보이는 변경이며, 별도 승인 대상으로 남긴다.
+
+### canonical 문서 어휘 보강과 재측정 (2026-08-08)
+
+miss 2건의 원인이 corpus 어휘 공백이었으므로 canonical MDX 본문에 사용자 어휘를 병기했다. **heading은 건드리지 않았다** — anchor ID와 deep link, TOC ownership, 그리고 평가 case의 `expectedSections`가 모두 heading에 묶여 있다.
+
+| 파일                     | 변경                                                                 |
+| ------------------------ | -------------------------------------------------------------------- |
+| `getting-started.ko.mdx` | "앱의 **진입점**에서 ... 진입점을 바꾸는 곳은 보통 `main.tsx`입니다" |
+| `getting-started.en.mdx` | "In your app **entry point** ... usually `main.tsx`" (KO/EN 대칭)    |
+| `troubleshooting.ko.mdx` | "그래서 **첫 렌더**에서는 data가 **비어** 보일 수 있습니다"          |
+| `troubleshooting.en.mdx` | "The data can therefore look **empty** on the very **first render**" |
+
+| 지표                 | 보강 전 | 보강 후                         |
+| -------------------- | ------- | ------------------------------- |
+| Hit@3 (embedding)    | 85.7%   | **100%**                        |
+| MRR                  | 0.643   | **0.750** (KO 0.667 / EN 0.833) |
+| `ko-6`               | miss    | **rank 2**                      |
+| `en-2`               | miss    | **rank 1**                      |
+| Hit@3 (keyword/BM25) | 57.1%   | 71.4%                           |
+
+**keyword도 함께 올랐다는 점이 중요하다.** 임베딩만 좋아졌다면 특정 검색기에 대한 최적화를 의심해야 하지만, 어휘 자체가 없던 문제였으므로 두 검색 방식이 같이 개선됐다. 진단이 맞았다는 독립 신호다.
+
+### 이 100%를 읽는 법
+
+**`ko-6`과 `en-2`는 더 이상 독립 증거가 아니다.** 그 두 case 때문에 문서를 고쳤으므로, 두 case의 통과는 "고친 것이 의도대로 동작한다"는 확인이지 검색 품질의 독립 측정이 아니다. 나머지 12건은 문서 변경 전에 이미 통과했으므로 영향받지 않는다.
+
+앞으로 실제 사용자 질문에서 새 case를 추가할 때가 독립 검증 시점이다.
+
+### 해석의 한계
+
+- 14개 case는 구현자가 문서를 읽고 작성했다. 실행 전에 고정했고 기대 section 실존을 test로 검증했지만, **문서에 있는 어휘로 질문했다는 편향**은 남는다. 문서에 없는 표현으로 묻는 실제 사용자를 대표하지 않는다.
+- OOD 8건과 32회 generation은 위반율을 정밀하게 추정하기엔 작은 표본이다. "32건 중 2건"을 위반율 6%로 읽지 않는다. 확인된 것은 **위반이 실재하고 KO in-domain 어휘 case에 몰린다**는 사실이며, 정확한 비율은 표본을 키워야 한다.
+- 이번 측정은 로컬 brute-force 결과다. 삭제된 Upstash 인덱스와 같은 embedding·같은 cosine·같은 정규화·같은 topK를 쓰고 벡터가 187개뿐이라 근사 최근접이 완전 탐색과 일치하므로 **동등하다고 판단**하지만, 실측 A/B는 아니다.
+
+## Closure
+
+- 현재 verdict: CLOSED — AC-E1~E8 충족
+- implementation: DONE
+- verification evidence: typecheck, lint, format:check, 전체 unit test, production build 통과. `ai:evaluate` 2회 실행으로 metric 재현 확인. `ai:plan` revision 회귀 없음
+- change risk: normal — 평가 경로는 신규이고, runtime 변경은 상수 추출과 lazy client 교정뿐이며 값과 동작은 동일하다
+- state drift: 없음 — 외부 vector/Redis 상태를 변경하지 않았다(대상 DB가 이미 삭제된 상태였고 로컬 artifact로 측정했다)
+- 다음 gate: 이번 측정이 상위 계획의 **retrieval 구조 결정**에 입력된다. T2 착수 전에 vector DB를 되살릴지 build artifact로 갈지 판단한다.


### PR DESCRIPTION
## What

- Retitle the RAG plan's baseline table as an authorship-time snapshot and add a "폐기된 항목" section, so deleted files are no longer described in the present tense.
- Replace the plan's `ai:index` / `ai:rollback` references with the commands that exist: `ai:build-index`, `ai:check-index`, `ai:evaluate`, `ai:probe-unknown`.
- Drop three statements that assume the abandoned T2/T3 design (an `ai:index` pointer-retention failure gate, an "close the Upstash postcondition before T2" instruction, and two planned files for those tasks).
- Repair a broken strikethrough in the progress list and label every row in the file-ownership table as 구현됨 or 미착수.
- Start tracking `docs/spec-packets/` by removing the local `.git/info/exclude` entry, and add the four packets that were previously invisible.

## Why

T2 and T3 were abandoned when the index moved into a committed build artifact, but the plan still read as if they were pending. A scan found eight stale claims in that one file: two deleted files presented as the current baseline, two commands that were never created, and four statements gated on an active pointer that no longer exists.

Separately, `docs/spec-packets/` was excluded through `.git/info/exclude`, which is machine-local. Only one packet had been committed, so the plan linked to a packet that does not exist in a fresh clone — it looked fine locally and broke for everyone else. Tracking the directory makes the links resolve and keeps the rejection history (five rejected alternatives in the T1 packet) available to the next reader.

The July packets surfaced from the same exclude removal. They are unrelated to this work, which is why they are a separate commit.

## Testing

Run on this branch:

- `pnpm run format:check` — passes, including the four newly tracked packets
- `pnpm --filter @firsttx/docs ai:check-index` — artifact still matches canonical revisions (ko `e38d8f4448de`, en `afb4eb76dcd6`)
- Re-scanned the plan for dead links, absent repo paths and absent `ai:*` scripts — 0 remaining. The six paths still cited are deliberate: two labelled 삭제됨 as history, four labelled 미착수 as planned files.

Not run: `pnpm run verify`. It includes `test:coverage`, which writes `coverage/` into the repo, so it was left out of this docs-only change. No source files changed.

## Breaking?

No. Documentation and repository tracking only; no code, dependency or CI behaviour changes.