### PR TITLE
fix(local-first): treat falsy initialData and version 0 as provided

### DIFF
--- a/packages/local-first/src/model.ts
+++ b/packages/local-first/src/model.ts
@@ -114,7 +114,7 @@ export function defineModel<T>(name: string, options: ModelOptions<T>): Model<T>
         model
           .getSnapshot()
           .then(async (data) => {
-            if (data) {
+            if (data !== null) {
               const history = await model.getHistory();
               cacheManager.updateWithData(data, history.updatedAt);
               cacheManager.setHistory(history);
@@ -157,7 +157,7 @@ export function defineModel<T>(name: string, options: ModelOptions<T>): Model<T>
   emitModelEvent('init', {
     modelName: model.name,
     ttl: model.ttl,
-    hasInitialData: !!options.initialData,
+    hasInitialData: options.initialData !== undefined,
     version: options.version,
   });
 

--- a/packages/local-first/src/storage-manager.ts
+++ b/packages/local-first/src/storage-manager.ts
@@ -43,10 +43,10 @@ export class StorageManager<T> {
       return null;
     }
 
-    if (this.version && stored._v !== this.version) {
+    if (this.version !== undefined && stored._v !== this.version) {
       await storage.delete(this.name);
 
-      if (this.initialData) {
+      if (this.initialData !== undefined) {
         const now = Date.now();
         await this.save(this.initialData);
         return {

--- a/packages/local-first/src/suspense.ts
+++ b/packages/local-first/src/suspense.ts
@@ -21,7 +21,7 @@ export function useSuspenseSyncedModel<T>(
     () => model.getCombinedSnapshot(),
   );
 
-  if (!snapshot.data && !snapshot.error) {
+  if (snapshot.data === null && !snapshot.error) {
     const currentOptions = optionsRef.current;
     // eslint-disable-next-line
     throw model.getSyncPromise(stableFetcher, {
@@ -35,7 +35,7 @@ export function useSuspenseSyncedModel<T>(
     throw snapshot.error;
   }
 
-  if (!snapshot.data) {
+  if (snapshot.data === null) {
     throw new Error(
       `[useSuspenseSyncedModel] Model "${model.name}" returned null after sync. ` +
         `This indicates the fetcher returned null/undefined.`,

--- a/packages/local-first/src/sync-manager.ts
+++ b/packages/local-first/src/sync-manager.ts
@@ -38,7 +38,7 @@ export class SyncManager<T> {
   ): Promise<T> {
     const cached = this.cacheManager.getCachedSnapshot();
 
-    if (cached && this.cachedDataPromise) {
+    if (cached !== null && this.cachedDataPromise) {
       return this.cachedDataPromise;
     }
 
@@ -46,7 +46,7 @@ export class SyncManager<T> {
       return this.syncPromise;
     }
 
-    if (cached) {
+    if (cached !== null) {
       this.cachedDataPromise = Promise.resolve(cached);
       return this.cachedDataPromise;
     }
@@ -193,7 +193,7 @@ export class SyncManager<T> {
         draft = structuredClone(existing.data);
       } else {
         const initialData = this.storageManager.getInitialData();
-        if (!initialData) {
+        if (initialData === undefined) {
           throw new Error(
             `[FirstTx] Cannot patch model "${this.name}" - no data exists and no initialData provided`,
           );

--- a/packages/local-first/tests/falsy-values.dom.test.ts
+++ b/packages/local-first/tests/falsy-values.dom.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { z } from 'zod';
+import { Suspense, createElement } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { defineModel } from '../src/model';
+import { useSuspenseSyncedModel } from '../src/suspense';
+import { Storage } from '../src/storage';
+
+describe('falsy primitive values (DOM)', () => {
+  beforeEach(() => {
+    indexedDB.deleteDatabase('firsttx-local-first');
+    Storage.setInstance(undefined);
+  });
+
+  afterEach(() => {
+    delete window.__FIRSTTX_DEVTOOLS__;
+    vi.restoreAllMocks();
+  });
+
+  describe('useSuspenseSyncedModel', () => {
+    it('should render cached 0 without suspending on a refetch', async () => {
+      const TestModel = defineModel('suspense-zero', {
+        schema: z.number(),
+        ttl: 5000,
+      });
+
+      await TestModel.replace(0);
+
+      const fetcher = vi.fn().mockResolvedValue(1);
+
+      function Child() {
+        const value = useSuspenseSyncedModel(TestModel, fetcher);
+        return createElement('span', { 'data-testid': 'value' }, String(value));
+      }
+
+      render(
+        createElement(
+          Suspense,
+          { fallback: createElement('span', null, 'loading') },
+          createElement(Child),
+        ),
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByTestId('value').textContent).toBe('0');
+        },
+        { timeout: 2000 },
+      );
+
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it('should render cached empty string without suspending on a refetch', async () => {
+      const TestModel = defineModel('suspense-empty', {
+        schema: z.string(),
+        ttl: 5000,
+      });
+
+      await TestModel.replace('');
+
+      const fetcher = vi.fn().mockResolvedValue('server');
+
+      function Child() {
+        const value = useSuspenseSyncedModel(TestModel, fetcher);
+        return createElement('span', { 'data-testid': 'value' }, `[${value}]`);
+      }
+
+      render(
+        createElement(
+          Suspense,
+          { fallback: createElement('span', null, 'loading') },
+          createElement(Child),
+        ),
+      );
+
+      await waitFor(
+        () => {
+          expect(screen.getByTestId('value').textContent).toBe('[]');
+        },
+        { timeout: 2000 },
+      );
+
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('devtools init event', () => {
+    it('should report hasInitialData=true for falsy initialData', () => {
+      const emit = vi.fn();
+      window.__FIRSTTX_DEVTOOLS__ = { emit };
+
+      defineModel('devtools-zero', {
+        schema: z.number(),
+        initialData: 0,
+        ttl: 5000,
+      });
+
+      const initEvent = emit.mock.calls
+        .map(([event]) => event as { type: string; data: { hasInitialData: boolean } })
+        .find((event) => event.type === 'init');
+
+      expect(initEvent?.data.hasInitialData).toBe(true);
+    });
+
+    it('should report hasInitialData=false when initialData is absent', () => {
+      const emit = vi.fn();
+      window.__FIRSTTX_DEVTOOLS__ = { emit };
+
+      defineModel('devtools-absent', {
+        schema: z.number(),
+        ttl: 5000,
+      });
+
+      const initEvent = emit.mock.calls
+        .map(([event]) => event as { type: string; data: { hasInitialData: boolean } })
+        .find((event) => event.type === 'init');
+
+      expect(initEvent?.data.hasInitialData).toBe(false);
+    });
+  });
+});

--- a/packages/local-first/tests/falsy-values.test.ts
+++ b/packages/local-first/tests/falsy-values.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { z } from 'zod';
+import { defineModel } from '../src/model';
+import { Storage } from '../src/storage';
+
+async function seed<T>(key: string, data: T, _v = 1): Promise<void> {
+  await Storage.getInstance().set(key, { _v, updatedAt: Date.now(), data });
+}
+
+async function until(predicate: () => boolean, timeout = 2000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeout) {
+      throw new Error('condition not met within timeout');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe('falsy primitive values', () => {
+  beforeEach(() => {
+    indexedDB.deleteDatabase('firsttx-local-first');
+    Storage.setInstance(undefined);
+  });
+
+  describe('subscribe - stored falsy data is restored', () => {
+    it('should restore stored 0 instead of falling back to initialData', async () => {
+      await seed('falsy-zero', 0);
+
+      const TestModel = defineModel('falsy-zero', {
+        schema: z.number(),
+        initialData: 7,
+        ttl: 5000,
+      });
+
+      TestModel.subscribe(() => {});
+
+      await until(() => TestModel.getCachedSnapshot() === 0);
+      expect(TestModel.getCachedSnapshot()).toBe(0);
+      expect(await TestModel.getSnapshot()).toBe(0);
+    });
+
+    it('should restore stored empty string instead of falling back to initialData', async () => {
+      await seed('falsy-empty', '');
+
+      const TestModel = defineModel('falsy-empty', {
+        schema: z.string(),
+        initialData: 'fallback',
+        ttl: 5000,
+      });
+
+      TestModel.subscribe(() => {});
+
+      await until(() => TestModel.getCachedSnapshot() === '');
+      expect(TestModel.getCachedSnapshot()).toBe('');
+      expect(await TestModel.getSnapshot()).toBe('');
+    });
+  });
+
+  describe('version reset - falsy initialData is used', () => {
+    it('should seed 0 after a version bump wipes stored data', async () => {
+      await seed('ver-reset-zero', 5, 1);
+
+      const TestModel = defineModel('ver-reset-zero', {
+        schema: z.number(),
+        version: 2,
+        initialData: 0,
+        ttl: 5000,
+      });
+
+      expect(await TestModel.getSnapshot()).toBe(0);
+
+      const history = await TestModel.getHistory();
+      expect(history.isStale).toBe(false);
+    });
+
+    it('should seed empty string after a version bump wipes stored data', async () => {
+      await seed('ver-reset-empty', 'old', 1);
+
+      const TestModel = defineModel('ver-reset-empty', {
+        schema: z.string(),
+        version: 2,
+        initialData: '',
+        ttl: 5000,
+      });
+
+      expect(await TestModel.getSnapshot()).toBe('');
+    });
+  });
+
+  describe('version option itself', () => {
+    it('should treat version 0 as a real version and reset mismatched data', async () => {
+      await seed('ver-zero', 'stale', 1);
+
+      const TestModel = defineModel('ver-zero', {
+        schema: z.string(),
+        version: 0,
+        initialData: 'fresh',
+        ttl: 5000,
+      });
+
+      expect(await TestModel.getSnapshot()).toBe('fresh');
+    });
+
+    it('should not reset data that already matches version 0', async () => {
+      await seed('ver-zero-match', 'kept', 0);
+
+      const TestModel = defineModel('ver-zero-match', {
+        schema: z.string(),
+        version: 0,
+        initialData: 'fresh',
+        ttl: 5000,
+      });
+
+      expect(await TestModel.getSnapshot()).toBe('kept');
+    });
+  });
+
+  describe('patch - falsy initialData counts as provided', () => {
+    it('should not throw "no initialData provided" when initialData is 0', async () => {
+      const TestModel = defineModel('patch-zero', {
+        schema: z.number(),
+        initialData: 0,
+        ttl: 5000,
+      });
+
+      await expect(TestModel.patch(() => {})).resolves.toBeUndefined();
+      expect(await TestModel.getSnapshot()).toBe(0);
+    });
+
+    it('should not throw "no initialData provided" when initialData is an empty string', async () => {
+      const TestModel = defineModel('patch-empty', {
+        schema: z.string(),
+        initialData: '',
+        ttl: 5000,
+      });
+
+      await expect(TestModel.patch(() => {})).resolves.toBeUndefined();
+      expect(await TestModel.getSnapshot()).toBe('');
+    });
+
+    it('should still throw when initialData is genuinely absent', async () => {
+      const TestModel = defineModel('patch-absent', {
+        schema: z.number(),
+        ttl: 5000,
+      });
+
+      await expect(TestModel.patch(() => {})).rejects.toThrow('no initialData provided');
+    });
+  });
+
+  describe('getSyncPromise - cached falsy value is a cache hit', () => {
+    it('should resolve cached 0 without invoking the fetcher', async () => {
+      const TestModel = defineModel('sync-zero', {
+        schema: z.number(),
+        ttl: 5000,
+      });
+
+      await TestModel.replace(0);
+
+      const fetcher = vi.fn().mockResolvedValue(1);
+      await expect(TestModel.getSyncPromise(fetcher)).resolves.toBe(0);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it('should resolve cached empty string without invoking the fetcher', async () => {
+      const TestModel = defineModel('sync-empty', {
+        schema: z.string(),
+        ttl: 5000,
+      });
+
+      await TestModel.replace('');
+
+      const fetcher = vi.fn().mockResolvedValue('server');
+      await expect(TestModel.getSyncPromise(fetcher)).resolves.toBe('');
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## What

Align every "is this value present?" check in `@firsttx/local-first` on explicit
`!== undefined` / `!== null` comparisons instead of truthiness.

- `storage-manager.ts` — `version` is now compared with `!== undefined`, so
  `version: 0` is a real version instead of silently disabling the version
  check; the version-reset path seeds falsy `initialData` instead of returning
  `null`.
- `model.ts` — `subscribe()` restores stored `0` / `''` instead of overwriting
  them with `initialData`; the devtools `init` event reports
  `hasInitialData` by presence, not truthiness.
- `sync-manager.ts` — `getSyncPromise()` treats a cached falsy value as a cache
  hit; `patch()` accepts falsy `initialData` as provided.
- `suspense.ts` — `useSuspenseSyncedModel` no longer suspends forever on a
  falsy cached value.

Adds `tests/falsy-values.test.ts` and `tests/falsy-values.dom.test.ts`
(15 cases) covering `0` and `''` across load, version reset, patch, sync-promise
and suspense, plus guard rails for genuinely absent `initialData`.

## Why

`initialData` is typed `T` and the schema may be a primitive, so `0` and `''`
are valid inputs. Truthiness checks classified them as "no value", which meant
stored data was not restored and `patch()` failed with
`no data exists and no initialData provided`. `model.ts` already used
`options.initialData !== undefined` correctly, so the rest of the package is
aligned to that side rather than a new convention.

## Testing

- `pnpm --filter @firsttx/local-first test:run` — 12 of the 15 new cases failed
  before the fix, all 127 tests across 10 files pass after it
- `pnpm --filter @firsttx/local-first typecheck` — passes
- `pnpm --filter @firsttx/local-first lint` — 0 errors (3 pre-existing warnings
  come from generated `coverage/lcov-report/*` files)
- `pnpm test:run` — 10/10 workspace tasks succeed, no regressions

---

**Breaking?** No public API change — `ModelOptions` is untouched. One behavior
change: a model declared with `version: 0` previously skipped the version check
entirely and now behaves as a real version, so stored data with a different `_v`
is reset. Data written by this package under `version: 0` was already persisted
as `_v: 0`, so it stays intact; no migration needed.